### PR TITLE
Allow skipping validation on project

### DIFF
--- a/dybdob-mojo/src/main/java/com/custardsource/dybdob/mojo/DybdobMojo.java
+++ b/dybdob-mojo/src/main/java/com/custardsource/dybdob/mojo/DybdobMojo.java
@@ -31,6 +31,14 @@ public abstract class DybdobMojo extends AbstractMojo {
     org.apache.maven.project.MavenProject mavenProject;
 
     /**
+     * Skip is enabled
+     *
+     * @parameter default-value=false
+     * @required
+     */
+    private boolean skip;
+
+    /**
      * Which detectors are enabled
      *
      * @parameter
@@ -47,11 +55,15 @@ public abstract class DybdobMojo extends AbstractMojo {
             return;
         }
 
+        if (skip) {
+            getLog().info("Skipping warning count" + mavenProject.getPackaging());
+            return;
+        }
+
         initialize();
         checkWarningCounts();
         tearDown();
     }
-
     protected abstract void tearDown();
 
     private void checkWarningCounts() throws MojoExecutionException {


### PR DESCRIPTION
We would like to skip the validation on projects without any java code. e.g script and contract modules. 

Currently we can only achieve this by marking the project pom `packaging` attribute as a non-jar ( e.g pom rar or war) to avoid checking on non-existed src files.

This PR will enable user to explicitly configure the module to avoid the validation on such projects.

For instance,
```

<configuration>
  <skip>true</skip>
</configuration>
```
will skip the validation.

Please approve this PR and release a new version.
Thanks.