### PR TITLE
Adding new Detector for findsecbugs to keep track threshold values for security bugs separately

### DIFF
--- a/dybdob-detectors/src/main/java/com/custardsource/dybdob/detectors/FindBugsDetector.java
+++ b/dybdob-detectors/src/main/java/com/custardsource/dybdob/detectors/FindBugsDetector.java
@@ -19,8 +19,8 @@ import java.io.IOException;
 import java.util.Map;
 
 public class FindBugsDetector extends AbstractDetector {
-    public FindBugsDetector() {
-        super("findbugs");
+    public FindBugsDetector(String id) {
+        super(id);
     }
 
     @Override

--- a/dybdob-detectors/src/test/java/com/custardsource/dybdob/detectors/FindBugsDetectorTest.java
+++ b/dybdob-detectors/src/test/java/com/custardsource/dybdob/detectors/FindBugsDetectorTest.java
@@ -10,27 +10,46 @@ import static org.hamcrest.Matchers.is;
 @Test
 public class FindBugsDetectorTest {
     private static final File FINDBUGS_XML = new File(ClassLoader.getSystemClassLoader().getResource("findbugsXml.xml").getPath());
+    private static final File FINDSECBUGS_XML = new File(ClassLoader.getSystemClassLoader().getResource("findsecbugsXml.xml").getPath());
+    private static final String FINDBUGS_DETECTOR_IDENTIFIER = "findbugs";
+    private static final String FINDSECBUGS_DETECTOR_IDENTIFIER = "findsecbugs";
     private static final File FINDBUGS_XML_NO_HIGH_PRIORITY = new File(ClassLoader.getSystemClassLoader().getResource("findbugsXmlNoHighPriority.xml").getPath());
 
     public void shouldFind37BugsInTotal() {
-        assertThat(new FindBugsDetector().getResultsFrom(FINDBUGS_XML).get("all"), is(37));
+        assertThat(new FindBugsDetector(FINDBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDBUGS_XML).get("all"), is(37));
     }
 
     public void shouldFind3HighPriorityBugs() {
-        assertThat(new FindBugsDetector().getResultsFrom(FINDBUGS_XML).get("high"), is(3));
+        assertThat(new FindBugsDetector(FINDBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDBUGS_XML).get("high"), is(3));
     }
 
     public void shouldFind0HighPriorityBugsWhenNoSuchAttributeExists() {
-        assertThat(new FindBugsDetector().getResultsFrom(FINDBUGS_XML_NO_HIGH_PRIORITY).get("high"), is(0));
+        assertThat(new FindBugsDetector(FINDBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDBUGS_XML_NO_HIGH_PRIORITY).get("high"), is(0));
     }
 
 
     public void shouldFind11NormalPriorityBugs() {
-        assertThat(new FindBugsDetector().getResultsFrom(FINDBUGS_XML).get("normal"), is(11));
+        assertThat(new FindBugsDetector(FINDBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDBUGS_XML).get("normal"), is(11));
     }
 
     public void shouldFind23LowPriorityBugs() {
-        assertThat(new FindBugsDetector().getResultsFrom(FINDBUGS_XML).get("low"), is(23));
+        assertThat(new FindBugsDetector(FINDBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDBUGS_XML).get("low"), is(23));
+    }
+
+    public void shouldFind9SecurityBugsInTotal() {
+        assertThat(new FindBugsDetector(FINDSECBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDSECBUGS_XML).get("all"), is(9));
+    }
+
+    public void shouldFind6HighPrioritySecurityBugs() {
+        assertThat(new FindBugsDetector(FINDSECBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDSECBUGS_XML).get("high"), is(0));
+    }
+
+    public void shouldFind6NormalPrioritySecurityBugs() {
+        assertThat(new FindBugsDetector(FINDSECBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDSECBUGS_XML).get("normal"), is(6));
+    }
+
+    public void shouldFind3LowPrioritySecurityBugs() {
+        assertThat(new FindBugsDetector(FINDSECBUGS_DETECTOR_IDENTIFIER).getResultsFrom(FINDSECBUGS_XML).get("low"), is(3));
     }
 
 }

--- a/dybdob-detectors/src/test/resources/findbugsXml.xml
+++ b/dybdob-detectors/src/test/resources/findbugsXml.xml
@@ -1,412 +1,213 @@
 <BugCollection timestamp='1282545580000' analysisTimestamp='1282545593845' sequence='0' release='' version='1.3.9'>
   <Project projectName=''>
-    <Jar>/home/ykulbak/dev/babylon-git/utilities/aconex-utils/target/classes</Jar>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/apache/maven/reporting/maven-reporting-impl/2.0/maven-reporting-impl-2.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-validator/commons-validator/1.1.4/commons-validator-1.1.4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/oro/oro/2.0.7/oro-2.0.7.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/doxia/doxia-core/1.0-alpha-4/doxia-core-1.0-alpha-4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/apache/maven/shared/maven-doxia-tools/1.0/maven-doxia-tools-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-io/commons-io/1.4/commons-io-1.4.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/apache/maven/doxia/doxia-decoration-model/1.0-alpha-11/doxia-decoration-model-1.0-alpha-11.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/findbugs-ant/1.3.9/findbugs-ant-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/findbugs/1.3.9/findbugs-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/bcel/1.3.9/bcel-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/jFormatString/1.3.9/jFormatString-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/annotations/1.3.9/annotations-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jaxen/jaxen/1.1.1/jaxen-1.1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jdom/jdom/1.0/jdom-1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xerces/xercesImpl/2.6.2/xercesImpl-2.6.2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xom/xom/1.0/xom-1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xerces/xmlParserAPIs/2.6.2/xmlParserAPIs-2.6.2.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xalan/xalan/2.6.0/xalan-2.6.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/ibm/icu/icu4j/2.6.1/icu4j-2.6.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm/3.1/asm-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-analysis/3.1/asm-analysis-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-tree/3.1/asm-tree-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-commons/3.1/asm-commons-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-util/3.1/asm-util-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-xml/3.1/asm-xml-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-lang/commons-lang/2.4/commons-lang-2.4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jgoodies/plastic/1.2.0/plastic-1.2.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/gmaven-mojo/1.0-rc-3/gmaven-mojo-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-api/1.0-rc-3/gmaven-runtime-api-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/feature/gmaven-feature-api/1.0-rc-3/gmaven-feature-api-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-default/1.0-rc-3/gmaven-runtime-default-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/slf4j/slf4j-api/1.5.0/slf4j-api-1.5.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-1.5/1.0-rc-3/gmaven-runtime-1.5-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/feature/gmaven-feature-support/1.0-rc-3/gmaven-feature-support-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-support/1.0-rc-3/gmaven-runtime-support-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/gmaven-common/1.0-rc-3/gmaven-common-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/thoughtworks/qdox/qdox/1.6.3/qdox-1.6.3.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/groovy-all-minimal/1.5.6/groovy-all-minimal-1.5.6.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant/1.7.1/ant-1.7.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant-launcher/1.7.1/ant-launcher-1.7.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jline/jline/0.9.94/jline-0.9.94.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/plexus/plexus-resources/1.0-alpha-4/plexus-resources-1.0-alpha-4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/dev/java/apache-maven-2.2.1/lib/maven-2.2.1-uber.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/aconex/utils/aconex-intelligent-test/1.0.0/aconex-intelligent-test-1.0.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/mail/mail/1.4/mail-1.4.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/springframework/spring/2.5.6/spring-2.5.6.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/hibernate/hibernate-core/3.3.1.GA/hibernate-core-3.3.1.GA.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/antlr/antlr/2.7.6/antlr-2.7.6.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/transaction/jta/1.1/jta-1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-codec/commons-codec/1.3/commons-codec-1.3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/log4j/log4j/1.2.14/log4j-1.2.14.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant/1.7.0/ant-1.7.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant-launcher/1.7.0/ant-launcher-1.7.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-dbutils/commons-dbutils/1.1/commons-dbutils-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/thoughtworks/xstream/xstream/1.3.1/xstream-1.3.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xpp3/xpp3_min/1.1.3.4.O/xpp3_min-1.1.3.4.O.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/velocity/velocity/1.5/velocity-1.5.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-math/commons-math/1.2/commons-math-1.2.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/velocity/velocity-tools/1.3/velocity-tools-1.3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/sslext/sslext/1.2-0/sslext-1.2-0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/struts/struts/1.2.9/struts-1.2.9.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-fileupload/commons-fileupload/1.0/commons-fileupload-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xalan/xalan/2.5.1/xalan-2.5.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/velocity/velocity/1.4/velocity-1.4.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/hibernate/hibernate-commons-annotations/3.3.0.ga/hibernate-commons-annotations-3.3.0.ga.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-spring-utils/1.9/aconex-spring-utils-1.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/persistence/persistence-api/1.0/persistence-api-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/utils/aconex-utils-lang/1.0.8/aconex-utils-lang-1.0.8.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/joda-time/joda-time/1.2.1.20071016/joda-time-1.2.1.20071016.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/aconex/utils/aconex-utils-collections/1.0.14/aconex-utils-collections-1.0.14.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-assert/1.3/aconex-assert-1.3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/aconex/aconex-applicationexception/1.1/aconex-applicationexception-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/guava/guava/r05/guava-r05.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/utils/aconex-utils-db/1.2/aconex-utils-db-1.2.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/mockito/mockito-core/1.8.0/mockito-core-1.8.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/objenesis/objenesis/1.0/objenesis-1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/c3p0/c3p0/0.9.1.2/c3p0-0.9.1.2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-jtds/1.2.1.7/aconex-jtds-1.2.1.7.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/samba/jcifs/jcifs/1.2.15/jcifs-1.2.15.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/custardsource/parfait/parfait-core/0.2.2-SNAPSHOT/parfait-core-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/measure/jsr-275/0.9.1/jsr-275-0.9.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/custardsource/parfait/parfait-pcp/0.2.2-SNAPSHOT/parfait-pcp-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/custardsource/parfait/dxm/0.2.2-SNAPSHOT/dxm-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/custardsource/parfait/parfait-spring/0.2.2-SNAPSHOT/parfait-spring-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/aspectj/aspectjweaver/1.6.1/aspectjweaver-1.6.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-i18n-utils/1.0.10/aconex-i18n-utils-1.0.10.jar
-    </AuxClasspathEntry>
-    <SrcDir>/home/ykulbak/dev/babylon-git/utilities/aconex-utils/src/main/java</SrcDir>
-    <WrkDir>/home/ykulbak/dev/babylon-git/utilities/aconex-utils/target</WrkDir>
   </Project>
   <BugInstance category='CORRECTNESS' instanceHash='700a71ba286b5cae4962b2f59b772eb5' instanceOccurrenceNum='0' priority='2' abbrev='UwF' type='UWF_UNWRITTEN_FIELD' instanceOccurrenceMax='0'>
     <ShortMessage>Unwritten field</ShortMessage>
-    <LongMessage>Unwritten field: com.aconex.db.JdbcSettingsMBean.instance</LongMessage>
-    <Class classname='com.aconex.db.JdbcSettingsMBean' primary='true'>
-      <SourceLine start='7' classname='com.aconex.db.JdbcSettingsMBean' sourcepath='com/aconex/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='37'>
+    <LongMessage>Unwritten field: somepackage.db.JdbcSettingsMBean.instance</LongMessage>
+    <Class classname='somepackage.db.JdbcSettingsMBean' primary='true'>
+      <SourceLine start='7' classname='somepackage.db.JdbcSettingsMBean' sourcepath='somepackage/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='37'>
         <Message>At JdbcSettingsMBean.java:[lines 7-37]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.JdbcSettingsMBean</Message>
+      <Message>In class somepackage.db.JdbcSettingsMBean</Message>
     </Class>
-    <Field isStatic='true' classname='com.aconex.db.JdbcSettingsMBean' name='instance' primary='true' signature='Lcom/aconex/db/JdbcSettingsMBean;'>
-      <SourceLine classname='com.aconex.db.JdbcSettingsMBean' sourcepath='com/aconex/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java'>
+    <Field isStatic='true' classname='somepackage.db.JdbcSettingsMBean' name='instance' primary='true' signature='Lsomepackage/db/JdbcSettingsMBean;'>
+      <SourceLine classname='somepackage.db.JdbcSettingsMBean' sourcepath='somepackage/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java'>
         <Message>In JdbcSettingsMBean.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.JdbcSettingsMBean.instance</Message>
+      <Message>Field somepackage.db.JdbcSettingsMBean.instance</Message>
     </Field>
-    <SourceLine endBytecode='0' startBytecode='0' start='12' classname='com.aconex.db.JdbcSettingsMBean' primary='true' sourcepath='com/aconex/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='12'>
+    <SourceLine endBytecode='0' startBytecode='0' start='12' classname='somepackage.db.JdbcSettingsMBean' primary='true' sourcepath='somepackage/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='12'>
       <Message>At JdbcSettingsMBean.java:[line 12]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='6dd87f6a319d350d0484b038ec9b6d08' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
     <LongMessage>Exception is caught when Exception is not thrown in
-      com.aconex.db.LegacyService.installAsStaticInstance()
+      somepackage.db.LegacyService.installAsStaticInstance()
     </LongMessage>
-    <Class classname='com.aconex.db.LegacyService' primary='true'>
-      <SourceLine start='31' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
+    <Class classname='somepackage.db.LegacyService' primary='true'>
+      <SourceLine start='31' classname='somepackage.db.LegacyService' sourcepath='somepackage/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
         <Message>At LegacyService.java:[lines 31-133]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.LegacyService</Message>
+      <Message>In class somepackage.db.LegacyService</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.LegacyService' name='installAsStaticInstance' primary='true' signature='()V'>
-      <SourceLine endBytecode='169' startBytecode='0' start='109' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='116'></SourceLine>
-      <Message>In method com.aconex.db.LegacyService.installAsStaticInstance()</Message>
+    <Method isStatic='false' classname='somepackage.db.LegacyService' name='installAsStaticInstance' primary='true' signature='()V'>
+      <SourceLine endBytecode='169' startBytecode='0' start='109' classname='somepackage.db.LegacyService' sourcepath='somepackage/db/LegacyService.java' sourcefile='LegacyService.java' end='116'></SourceLine>
+      <Message>In method somepackage.db.LegacyService.installAsStaticInstance()</Message>
     </Method>
-    <SourceLine endBytecode='52' startBytecode='52' start='113' classname='com.aconex.db.LegacyService' primary='true' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='113'>
+    <SourceLine endBytecode='52' startBytecode='52' start='113' classname='somepackage.db.LegacyService' primary='true' sourcepath='somepackage/db/LegacyService.java' sourcefile='LegacyService.java' end='113'>
       <Message>At LegacyService.java:[line 113]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='4d23aeaaf1a8a49ff660ee05e4542b9' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
     <LongMessage>Exception is caught when Exception is not thrown in
-      com.aconex.db.LegacyService.uninstallAsStaticInstance()
+      somepackage.db.LegacyService.uninstallAsStaticInstance()
     </LongMessage>
-    <Class classname='com.aconex.db.LegacyService' primary='true'>
-      <SourceLine start='31' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
+    <Class classname='somepackage.db.LegacyService' primary='true'>
+      <SourceLine start='31' classname='somepackage.db.LegacyService' sourcepath='somepackage/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
         <Message>At LegacyService.java:[lines 31-133]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.LegacyService</Message>
+      <Message>In class somepackage.db.LegacyService</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.LegacyService' name='uninstallAsStaticInstance' primary='true' signature='()V'>
-      <SourceLine endBytecode='195' startBytecode='0' start='120' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='128'></SourceLine>
-      <Message>In method com.aconex.db.LegacyService.uninstallAsStaticInstance()</Message>
+    <Method isStatic='false' classname='somepackage.db.LegacyService' name='uninstallAsStaticInstance' primary='true' signature='()V'>
+      <SourceLine endBytecode='195' startBytecode='0' start='120' classname='somepackage.db.LegacyService' sourcepath='somepackage/db/LegacyService.java' sourcefile='LegacyService.java' end='128'></SourceLine>
+      <Message>In method somepackage.db.LegacyService.uninstallAsStaticInstance()</Message>
     </Method>
-    <SourceLine endBytecode='61' startBytecode='61' start='125' classname='com.aconex.db.LegacyService' primary='true' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='125'>
+    <SourceLine endBytecode='61' startBytecode='61' start='125' classname='somepackage.db.LegacyService' primary='true' sourcepath='somepackage/db/LegacyService.java' sourcefile='LegacyService.java' end='125'>
       <Message>At LegacyService.java:[line 125]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='d4eafdd8d320bab2e1e0af42e567af45' instanceOccurrenceNum='0' priority='2' abbrev='EI2' type='EI_EXPOSE_REP2' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.aconex.db.hibernate.BaseInExpression(Object[], Criterion) may expose internal representation by
+    <LongMessage>new somepackage.db.hibernate.BaseInExpression(Object[], Criterion) may expose internal representation by
       storing an externally mutable object into BaseInExpression.values
     </LongMessage>
-    <Class classname='com.aconex.db.hibernate.BaseInExpression' primary='true'>
-      <SourceLine start='30' classname='com.aconex.db.hibernate.BaseInExpression' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='99'>
+    <Class classname='somepackage.db.hibernate.BaseInExpression' primary='true'>
+      <SourceLine start='30' classname='somepackage.db.hibernate.BaseInExpression' sourcepath='somepackage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='99'>
         <Message>At BaseInExpression.java:[lines 30-99]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.hibernate.BaseInExpression</Message>
+      <Message>In class somepackage.db.hibernate.BaseInExpression</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.hibernate.BaseInExpression' name='&lt;init&gt;' primary='true' signature='([Ljava/lang/Object;Lorg/hibernate/criterion/Criterion;)V'>
-      <SourceLine endBytecode='88' startBytecode='0' start='30' classname='com.aconex.db.hibernate.BaseInExpression' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='33'></SourceLine>
-      <Message>In method new com.aconex.db.hibernate.BaseInExpression(Object[], Criterion)</Message>
+    <Method isStatic='false' classname='somepackage.db.hibernate.BaseInExpression' name='&lt;init&gt;' primary='true' signature='([Ljava/lang/Object;Lorg/hibernate/criterion/Criterion;)V'>
+      <SourceLine endBytecode='88' startBytecode='0' start='30' classname='somepackage.db.hibernate.BaseInExpression' sourcepath='somepackage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='33'></SourceLine>
+      <Message>In method new somepackage.db.hibernate.BaseInExpression(Object[], Criterion)</Message>
     </Method>
-    <Field isStatic='false' classname='com.aconex.db.hibernate.BaseInExpression' name='values' primary='true' signature='[Ljava/lang/Object;'>
-      <SourceLine classname='com.aconex.db.hibernate.BaseInExpression' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java'>
+    <Field isStatic='false' classname='somepackage.db.hibernate.BaseInExpression' name='values' primary='true' signature='[Ljava/lang/Object;'>
+      <SourceLine classname='somepackage.db.hibernate.BaseInExpression' sourcepath='somepackage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java'>
         <Message>In BaseInExpression.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.hibernate.BaseInExpression.values</Message>
+      <Message>Field somepackage.db.hibernate.BaseInExpression.values</Message>
     </Field>
     <LocalVariable register='1' name='values' pc='6' role='LOCAL_VARIABLE_NAMED'>
       <Message>Local variable named values</Message>
     </LocalVariable>
-    <SourceLine endBytecode='6' startBytecode='6' start='31' classname='com.aconex.db.hibernate.BaseInExpression' primary='true' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='31'>
+    <SourceLine endBytecode='6' startBytecode='6' start='31' classname='somepackage.db.hibernate.BaseInExpression' primary='true' sourcepath='somepackage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='31'>
       <Message>At BaseInExpression.java:[line 31]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='8c159f580ea7284066808f78a827105e' instanceOccurrenceNum='0' priority='2' abbrev='EI' type='EI_EXPOSE_REP' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.aconex.db.usertypes.KeyedEnumUserType.sqlTypes() may expose internal representation by returning
+    <LongMessage>somepackage.db.usertypes.KeyedEnumUserType.sqlTypes() may expose internal representation by returning
       KeyedEnumUserType.RETURN_TYPE
     </LongMessage>
-    <Class classname='com.aconex.db.usertypes.KeyedEnumUserType' primary='true'>
-      <SourceLine start='37' classname='com.aconex.db.usertypes.KeyedEnumUserType' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='150'>
+    <Class classname='somepackage.db.usertypes.KeyedEnumUserType' primary='true'>
+      <SourceLine start='37' classname='somepackage.db.usertypes.KeyedEnumUserType' sourcepath='somepackage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='150'>
         <Message>At KeyedEnumUserType.java:[lines 37-150]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.usertypes.KeyedEnumUserType</Message>
+      <Message>In class somepackage.db.usertypes.KeyedEnumUserType</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.usertypes.KeyedEnumUserType' name='sqlTypes' primary='true' signature='()[I'>
-      <SourceLine endBytecode='45' startBytecode='0' start='93' classname='com.aconex.db.usertypes.KeyedEnumUserType' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'></SourceLine>
-      <Message>In method com.aconex.db.usertypes.KeyedEnumUserType.sqlTypes()</Message>
+    <Method isStatic='false' classname='somepackage.db.usertypes.KeyedEnumUserType' name='sqlTypes' primary='true' signature='()[I'>
+      <SourceLine endBytecode='45' startBytecode='0' start='93' classname='somepackage.db.usertypes.KeyedEnumUserType' sourcepath='somepackage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'></SourceLine>
+      <Message>In method somepackage.db.usertypes.KeyedEnumUserType.sqlTypes()</Message>
     </Method>
-    <Field isStatic='true' classname='com.aconex.db.usertypes.KeyedEnumUserType' name='RETURN_TYPE' primary='true' signature='[I'>
-      <SourceLine classname='com.aconex.db.usertypes.KeyedEnumUserType' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java'>
+    <Field isStatic='true' classname='somepackage.db.usertypes.KeyedEnumUserType' name='RETURN_TYPE' primary='true' signature='[I'>
+      <SourceLine classname='somepackage.db.usertypes.KeyedEnumUserType' sourcepath='somepackage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java'>
         <Message>In KeyedEnumUserType.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.usertypes.KeyedEnumUserType.RETURN_TYPE</Message>
+      <Message>Field somepackage.db.usertypes.KeyedEnumUserType.RETURN_TYPE</Message>
     </Field>
-    <SourceLine endBytecode='3' startBytecode='3' start='93' classname='com.aconex.db.usertypes.KeyedEnumUserType' primary='true' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'>
+    <SourceLine endBytecode='3' startBytecode='3' start='93' classname='somepackage.db.usertypes.KeyedEnumUserType' primary='true' sourcepath='somepackage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'>
       <Message>At KeyedEnumUserType.java:[line 93]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='6cbe066798c4abb901a3d6e15aa0ec6b' instanceOccurrenceNum='0' priority='2' abbrev='EI' type='EI_EXPOSE_REP' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.aconex.db.usertypes.XStreamUserType.sqlTypes() may expose internal representation by returning
+    <LongMessage>somepackage.db.usertypes.XStreamUserType.sqlTypes() may expose internal representation by returning
       XStreamUserType.SQL_TYPES
     </LongMessage>
-    <Class classname='com.aconex.db.usertypes.XStreamUserType' primary='true'>
-      <SourceLine start='27' classname='com.aconex.db.usertypes.XStreamUserType' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='86'>
+    <Class classname='somepackage.db.usertypes.XStreamUserType' primary='true'>
+      <SourceLine start='27' classname='somepackage.db.usertypes.XStreamUserType' sourcepath='somepackage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='86'>
         <Message>At XStreamUserType.java:[lines 27-86]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.usertypes.XStreamUserType</Message>
+      <Message>In class somepackage.db.usertypes.XStreamUserType</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.usertypes.XStreamUserType' name='sqlTypes' primary='true' signature='()[I'>
-      <SourceLine endBytecode='45' startBytecode='0' start='76' classname='com.aconex.db.usertypes.XStreamUserType' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'></SourceLine>
-      <Message>In method com.aconex.db.usertypes.XStreamUserType.sqlTypes()</Message>
+    <Method isStatic='false' classname='somepackage.db.usertypes.XStreamUserType' name='sqlTypes' primary='true' signature='()[I'>
+      <SourceLine endBytecode='45' startBytecode='0' start='76' classname='somepackage.db.usertypes.XStreamUserType' sourcepath='somepackage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'></SourceLine>
+      <Message>In method somepackage.db.usertypes.XStreamUserType.sqlTypes()</Message>
     </Method>
-    <Field isStatic='true' classname='com.aconex.db.usertypes.XStreamUserType' name='SQL_TYPES' primary='true' signature='[I'>
-      <SourceLine classname='com.aconex.db.usertypes.XStreamUserType' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java'>
+    <Field isStatic='true' classname='somepackage.db.usertypes.XStreamUserType' name='SQL_TYPES' primary='true' signature='[I'>
+      <SourceLine classname='somepackage.db.usertypes.XStreamUserType' sourcepath='somepackage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java'>
         <Message>In XStreamUserType.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.usertypes.XStreamUserType.SQL_TYPES</Message>
+      <Message>Field somepackage.db.usertypes.XStreamUserType.SQL_TYPES</Message>
     </Field>
-    <SourceLine endBytecode='3' startBytecode='3' start='76' classname='com.aconex.db.usertypes.XStreamUserType' primary='true' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'>
+    <SourceLine endBytecode='3' startBytecode='3' start='76' classname='somepackage.db.usertypes.XStreamUserType' primary='true' sourcepath='somepackage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'>
       <Message>At XStreamUserType.java:[line 76]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MT_CORRECTNESS' instanceHash='9b40d3bceffe850e64c00078ddebc8f5' instanceOccurrenceNum='0' priority='3' abbrev='IS' type='IS2_INCONSISTENT_SYNC' instanceOccurrenceMax='0'>
     <ShortMessage>Inconsistent synchronization</ShortMessage>
-    <LongMessage>Inconsistent synchronization of com.aconex.lockable.LockableSupport.lockedPermanently; locked 66% of
+    <LongMessage>Inconsistent synchronization of somepackage.lockable.LockableSupport.lockedPermanently; locked 66% of
       time
     </LongMessage>
-    <Class classname='com.aconex.lockable.LockableSupport' primary='true'>
-      <SourceLine start='13' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' sourcefile='LockableSupport.java' end='77'>
+    <Class classname='somepackage.lockable.LockableSupport' primary='true'>
+      <SourceLine start='13' classname='somepackage.lockable.LockableSupport' sourcepath='somepackage/lockable/LockableSupport.java' sourcefile='LockableSupport.java' end='77'>
         <Message>At LockableSupport.java:[lines 13-77]</Message>
       </SourceLine>
-      <Message>In class com.aconex.lockable.LockableSupport</Message>
+      <Message>In class somepackage.lockable.LockableSupport</Message>
     </Class>
-    <Field isStatic='false' classname='com.aconex.lockable.LockableSupport' name='lockedPermanently' primary='true' signature='Z'>
-      <SourceLine classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' sourcefile='LockableSupport.java'>
+    <Field isStatic='false' classname='somepackage.lockable.LockableSupport' name='lockedPermanently' primary='true' signature='Z'>
+      <SourceLine classname='somepackage.lockable.LockableSupport' sourcepath='somepackage/lockable/LockableSupport.java' sourcefile='LockableSupport.java'>
         <Message>In LockableSupport.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.lockable.LockableSupport.lockedPermanently</Message>
+      <Message>Field somepackage.lockable.LockableSupport.lockedPermanently</Message>
     </Field>
     <Int value='66' role='INT_SYNC_PERCENT'>
       <Message>Synchronized 66% of the time</Message>
     </Int>
-    <SourceLine endBytecode='1' startBytecode='1' start='34' classname='com.aconex.lockable.LockableSupport' primary='true' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_UNSYNC_ACCESS' sourcefile='LockableSupport.java' end='34'>
+    <SourceLine endBytecode='1' startBytecode='1' start='34' classname='somepackage.lockable.LockableSupport' primary='true' sourcepath='somepackage/lockable/LockableSupport.java' role='SOURCE_LINE_UNSYNC_ACCESS' sourcefile='LockableSupport.java' end='34'>
       <Message>Unsynchronized access at LockableSupport.java:[line 34]</Message>
     </SourceLine>
-    <SourceLine endBytecode='2' startBytecode='2' start='50' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='50'>
+    <SourceLine endBytecode='2' startBytecode='2' start='50' classname='somepackage.lockable.LockableSupport' sourcepath='somepackage/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='50'>
       <Message>Synchronized access at LockableSupport.java:[line 50]</Message>
     </SourceLine>
-    <SourceLine endBytecode='11' startBytecode='11' start='15' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='15'>
+    <SourceLine endBytecode='11' startBytecode='11' start='15' classname='somepackage.lockable.LockableSupport' sourcepath='somepackage/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='15'>
       <Message>Synchronized access at LockableSupport.java:[line 15]</Message>
     </SourceLine>
-    <SourceLine endBytecode='1' startBytecode='1' start='61' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='61'>
+    <SourceLine endBytecode='1' startBytecode='1' start='61' classname='somepackage.lockable.LockableSupport' sourcepath='somepackage/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='61'>
       <Message>Synchronized access at LockableSupport.java:[line 61]</Message>
     </SourceLine>
     <Property name='edu.umd.cs.findbugs.detect.InconsistentSyncWarningProperty.ONLY_UNSYNC_IN_GETTERS' value='true'></Property>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='7450e7e4f7615faea8e7c626fd718cd5' instanceOccurrenceNum='0' priority='2' abbrev='Se' type='SE_INNER_CLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Serializable inner class</ShortMessage>
-    <LongMessage>com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate is serializable and an inner class
+    <LongMessage>somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate is serializable and an inner class
     </LongMessage>
-    <Class classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
-      <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
+    <Class classname='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
+      <SourceLine start='156' classname='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepackage/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
         <Message>At XMLElement.java:[lines 156-175]</Message>
       </SourceLine>
-      <Message>In class com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
+      <Message>In class somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
     </Class>
-    <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
+    <SourceLine start='156' classname='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepackage/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
       <Message>At XMLElement.java:[lines 156-175]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='PERFORMANCE' instanceHash='fcc958dd49589a3a85dab990634c275c' instanceOccurrenceNum='0' priority='2' abbrev='SIC' type='SIC_INNER_SHOULD_BE_STATIC' instanceOccurrenceMax='0'>
     <ShortMessage>Should be a static inner class</ShortMessage>
-    <LongMessage>Should com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate be a _static_ inner class?
+    <LongMessage>Should somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate be a _static_ inner class?
     </LongMessage>
-    <Class classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
-      <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
+    <Class classname='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
+      <SourceLine start='156' classname='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepackage/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
         <Message>At XMLElement.java:[lines 156-175]</Message>
       </SourceLine>
-      <Message>In class com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
+      <Message>In class somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
     </Class>
-    <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
+    <SourceLine start='156' classname='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepackage/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
       <Message>At XMLElement.java:[lines 156-175]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='12b2510f81587883108009bfd6cf8631' instanceOccurrenceNum='0' priority='1' abbrev='Nm' type='NM_SAME_SIMPLE_NAME_AS_SUPERCLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Class names shouldn't shadow simple name of superclass</ShortMessage>
-    <LongMessage>The class name com.aconex.utilities.BeanUtils shadows the simple name of the superclass
+    <LongMessage>The class name somepackage.utilities.BeanUtils shadows the simple name of the superclass
       org.apache.commons.beanutils.BeanUtils
     </LongMessage>
-    <Class classname='com.aconex.utilities.BeanUtils' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.BeanUtils' sourcepath='com/aconex/utilities/BeanUtils.java' sourcefile='BeanUtils.java' end='32'>
+    <Class classname='somepackage.utilities.BeanUtils' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.BeanUtils' sourcepath='somepackage/utilities/BeanUtils.java' sourcefile='BeanUtils.java' end='32'>
         <Message>At BeanUtils.java:[lines 13-32]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.BeanUtils</Message>
+      <Message>In class somepackage.utilities.BeanUtils</Message>
     </Class>
     <Class classname='org.apache.commons.beanutils.BeanUtils'>
       <SourceLine start='42' classname='org.apache.commons.beanutils.BeanUtils' sourcepath='org/apache/commons/beanutils/BeanUtils.java' sourcefile='BeanUtils.java' end='314'>
@@ -414,20 +215,20 @@
       </SourceLine>
       <Message>In class org.apache.commons.beanutils.BeanUtils</Message>
     </Class>
-    <SourceLine start='13' classname='com.aconex.utilities.BeanUtils' sourcepath='com/aconex/utilities/BeanUtils.java' synthetic='true' sourcefile='BeanUtils.java' end='32'>
+    <SourceLine start='13' classname='somepackage.utilities.BeanUtils' sourcepath='somepackage/utilities/BeanUtils.java' synthetic='true' sourcefile='BeanUtils.java' end='32'>
       <Message>At BeanUtils.java:[lines 13-32]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='291b69d322e177eaaa3f2b8ab2ac80f' instanceOccurrenceNum='0' priority='1' abbrev='Nm' type='NM_SAME_SIMPLE_NAME_AS_SUPERCLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Class names shouldn't shadow simple name of superclass</ShortMessage>
-    <LongMessage>The class name com.aconex.utilities.NumberUtils shadows the simple name of the superclass
+    <LongMessage>The class name somepackage.utilities.NumberUtils shadows the simple name of the superclass
       org.apache.commons.lang.math.NumberUtils
     </LongMessage>
-    <Class classname='com.aconex.utilities.NumberUtils' primary='true'>
-      <SourceLine start='3' classname='com.aconex.utilities.NumberUtils' sourcepath='com/aconex/utilities/NumberUtils.java' sourcefile='NumberUtils.java' end='19'>
+    <Class classname='somepackage.utilities.NumberUtils' primary='true'>
+      <SourceLine start='3' classname='somepackage.utilities.NumberUtils' sourcepath='somepackage/utilities/NumberUtils.java' sourcefile='NumberUtils.java' end='19'>
         <Message>At NumberUtils.java:[lines 3-19]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.NumberUtils</Message>
+      <Message>In class somepackage.utilities.NumberUtils</Message>
     </Class>
     <Class classname='org.apache.commons.lang.math.NumberUtils'>
       <SourceLine start='41' classname='org.apache.commons.lang.math.NumberUtils' sourcepath='org/apache/commons/lang/math/NumberUtils.java' sourcefile='NumberUtils.java' end='1479'>
@@ -435,20 +236,20 @@
       </SourceLine>
       <Message>In class org.apache.commons.lang.math.NumberUtils</Message>
     </Class>
-    <SourceLine start='3' classname='com.aconex.utilities.NumberUtils' sourcepath='com/aconex/utilities/NumberUtils.java' synthetic='true' sourcefile='NumberUtils.java' end='19'>
+    <SourceLine start='3' classname='somepackage.utilities.NumberUtils' sourcepath='somepackage/utilities/NumberUtils.java' synthetic='true' sourcefile='NumberUtils.java' end='19'>
       <Message>At NumberUtils.java:[lines 3-19]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='4df0695eacb85cd9e071c34b0a4d9870' instanceOccurrenceNum='0' priority='1' abbrev='Nm' type='NM_SAME_SIMPLE_NAME_AS_SUPERCLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Class names shouldn't shadow simple name of superclass</ShortMessage>
-    <LongMessage>The class name com.aconex.utilities.StringEscapeUtils shadows the simple name of the superclass
+    <LongMessage>The class name somepackage.utilities.StringEscapeUtils shadows the simple name of the superclass
       org.apache.commons.lang.StringEscapeUtils
     </LongMessage>
-    <Class classname='com.aconex.utilities.StringEscapeUtils' primary='true'>
-      <SourceLine start='9' classname='com.aconex.utilities.StringEscapeUtils' sourcepath='com/aconex/utilities/StringEscapeUtils.java' sourcefile='StringEscapeUtils.java' end='35'>
+    <Class classname='somepackage.utilities.StringEscapeUtils' primary='true'>
+      <SourceLine start='9' classname='somepackage.utilities.StringEscapeUtils' sourcepath='somepackage/utilities/StringEscapeUtils.java' sourcefile='StringEscapeUtils.java' end='35'>
         <Message>At StringEscapeUtils.java:[lines 9-35]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.StringEscapeUtils</Message>
+      <Message>In class somepackage.utilities.StringEscapeUtils</Message>
     </Class>
     <Class classname='org.apache.commons.lang.StringEscapeUtils'>
       <SourceLine start='45' classname='org.apache.commons.lang.StringEscapeUtils' sourcepath='org/apache/commons/lang/StringEscapeUtils.java' sourcefile='StringEscapeUtils.java' end='858'>
@@ -456,105 +257,105 @@
       </SourceLine>
       <Message>In class org.apache.commons.lang.StringEscapeUtils</Message>
     </Class>
-    <SourceLine start='9' classname='com.aconex.utilities.StringEscapeUtils' sourcepath='com/aconex/utilities/StringEscapeUtils.java' synthetic='true' sourcefile='StringEscapeUtils.java' end='35'>
+    <SourceLine start='9' classname='somepackage.utilities.StringEscapeUtils' sourcepath='somepackage/utilities/StringEscapeUtils.java' synthetic='true' sourcefile='StringEscapeUtils.java' end='35'>
       <Message>At StringEscapeUtils.java:[lines 9-35]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='14eaa16dd47838de6319b1b27953b534' instanceOccurrenceNum='0' priority='2' abbrev='EI2' type='EI_EXPOSE_REP2' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.aconex.utilities.TimingStatistics.recordEvent(Date) may expose internal representation by storing
+    <LongMessage>somepackage.utilities.TimingStatistics.recordEvent(Date) may expose internal representation by storing
       an externally mutable object into TimingStatistics.lastEventStart
     </LongMessage>
-    <Class classname='com.aconex.utilities.TimingStatistics' primary='true'>
-      <SourceLine start='25' classname='com.aconex.utilities.TimingStatistics' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='121'>
+    <Class classname='somepackage.utilities.TimingStatistics' primary='true'>
+      <SourceLine start='25' classname='somepackage.utilities.TimingStatistics' sourcepath='somepackage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='121'>
         <Message>At TimingStatistics.java:[lines 25-121]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.TimingStatistics</Message>
+      <Message>In class somepackage.utilities.TimingStatistics</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.TimingStatistics' name='recordEvent' primary='true' signature='(Ljava/util/Date;)V'>
-      <SourceLine endBytecode='212' startBytecode='0' start='86' classname='com.aconex.utilities.TimingStatistics' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='94'></SourceLine>
-      <Message>In method com.aconex.utilities.TimingStatistics.recordEvent(Date)</Message>
+    <Method isStatic='false' classname='somepackage.utilities.TimingStatistics' name='recordEvent' primary='true' signature='(Ljava/util/Date;)V'>
+      <SourceLine endBytecode='212' startBytecode='0' start='86' classname='somepackage.utilities.TimingStatistics' sourcepath='somepackage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='94'></SourceLine>
+      <Message>In method somepackage.utilities.TimingStatistics.recordEvent(Date)</Message>
     </Method>
-    <Field isStatic='false' classname='com.aconex.utilities.TimingStatistics' name='lastEventStart' primary='true' signature='Ljava/util/Date;'>
-      <SourceLine classname='com.aconex.utilities.TimingStatistics' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java'>
+    <Field isStatic='false' classname='somepackage.utilities.TimingStatistics' name='lastEventStart' primary='true' signature='Ljava/util/Date;'>
+      <SourceLine classname='somepackage.utilities.TimingStatistics' sourcepath='somepackage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java'>
         <Message>In TimingStatistics.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.utilities.TimingStatistics.lastEventStart</Message>
+      <Message>Field somepackage.utilities.TimingStatistics.lastEventStart</Message>
     </Field>
     <LocalVariable register='1' name='eventStart' pc='68' role='LOCAL_VARIABLE_NAMED'>
       <Message>Local variable named eventStart</Message>
     </LocalVariable>
-    <SourceLine endBytecode='68' startBytecode='68' start='92' classname='com.aconex.utilities.TimingStatistics' primary='true' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='92'>
+    <SourceLine endBytecode='68' startBytecode='68' start='92' classname='somepackage.utilities.TimingStatistics' primary='true' sourcepath='somepackage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='92'>
       <Message>At TimingStatistics.java:[line 92]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='37142248cb7bd8f07c0a7bc2743eb416' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
-    <LongMessage>Exception is caught when Exception is not thrown in com.aconex.utilities.URLUtils.isDir(String)
+    <LongMessage>Exception is caught when Exception is not thrown in somepackage.utilities.URLUtils.isDir(String)
     </LongMessage>
-    <Class classname='com.aconex.utilities.URLUtils' primary='true'>
-      <SourceLine start='22' classname='com.aconex.utilities.URLUtils' sourcepath='com/aconex/utilities/URLUtils.java' sourcefile='URLUtils.java' end='346'>
+    <Class classname='somepackage.utilities.URLUtils' primary='true'>
+      <SourceLine start='22' classname='somepackage.utilities.URLUtils' sourcepath='somepackage/utilities/URLUtils.java' sourcefile='URLUtils.java' end='346'>
         <Message>At URLUtils.java:[lines 22-346]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.URLUtils</Message>
+      <Message>In class somepackage.utilities.URLUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.URLUtils' name='isDir' primary='true' signature='(Ljava/lang/String;)Z'>
-      <SourceLine endBytecode='280' startBytecode='0' start='217' classname='com.aconex.utilities.URLUtils' sourcepath='com/aconex/utilities/URLUtils.java' sourcefile='URLUtils.java' end='237'></SourceLine>
-      <Message>In method com.aconex.utilities.URLUtils.isDir(String)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.URLUtils' name='isDir' primary='true' signature='(Ljava/lang/String;)Z'>
+      <SourceLine endBytecode='280' startBytecode='0' start='217' classname='somepackage.utilities.URLUtils' sourcepath='somepackage/utilities/URLUtils.java' sourcefile='URLUtils.java' end='237'></SourceLine>
+      <Message>In method somepackage.utilities.URLUtils.isDir(String)</Message>
     </Method>
-    <SourceLine endBytecode='86' startBytecode='86' start='235' classname='com.aconex.utilities.URLUtils' primary='true' sourcepath='com/aconex/utilities/URLUtils.java' sourcefile='URLUtils.java' end='235'>
+    <SourceLine endBytecode='86' startBytecode='86' start='235' classname='somepackage.utilities.URLUtils' primary='true' sourcepath='somepackage/utilities/URLUtils.java' sourcefile='URLUtils.java' end='235'>
       <Message>At URLUtils.java:[line 235]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='392eae7778bff9ffdf48af0f265c5898' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
     <LongMessage>Exception is caught when Exception is not thrown in
-      com.aconex.utilities.XMLUtils.addElement(StringBuffer, String, Date)
+      somepackage.utilities.XMLUtils.addElement(StringBuffer, String, Date)
     </LongMessage>
-    <Class classname='com.aconex.utilities.XMLUtils' primary='true'>
-      <SourceLine start='14' classname='com.aconex.utilities.XMLUtils' sourcepath='com/aconex/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='66'>
+    <Class classname='somepackage.utilities.XMLUtils' primary='true'>
+      <SourceLine start='14' classname='somepackage.utilities.XMLUtils' sourcepath='somepackage/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='66'>
         <Message>At XMLUtils.java:[lines 14-66]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.XMLUtils</Message>
+      <Message>In class somepackage.utilities.XMLUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.XMLUtils' name='addElement' primary='true' signature='(Ljava/lang/StringBuffer;Ljava/lang/String;Ljava/util/Date;)V'>
-      <SourceLine endBytecode='229' startBytecode='0' start='46' classname='com.aconex.utilities.XMLUtils' sourcepath='com/aconex/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='54'></SourceLine>
-      <Message>In method com.aconex.utilities.XMLUtils.addElement(StringBuffer, String, Date)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.XMLUtils' name='addElement' primary='true' signature='(Ljava/lang/StringBuffer;Ljava/lang/String;Ljava/util/Date;)V'>
+      <SourceLine endBytecode='229' startBytecode='0' start='46' classname='somepackage.utilities.XMLUtils' sourcepath='somepackage/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='54'></SourceLine>
+      <Message>In method somepackage.utilities.XMLUtils.addElement(StringBuffer, String, Date)</Message>
     </Method>
-    <SourceLine endBytecode='62' startBytecode='62' start='51' classname='com.aconex.utilities.XMLUtils' primary='true' sourcepath='com/aconex/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='51'>
+    <SourceLine endBytecode='62' startBytecode='62' start='51' classname='somepackage.utilities.XMLUtils' primary='true' sourcepath='somepackage/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='51'>
       <Message>At XMLUtils.java:[line 51]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='2ca213d29bd65438d6c98b9f0fb0acee' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserProperties' primary='true'>
-      <SourceLine start='34' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
+    <Class classname='somepackage.utilities.browser.BrowserProperties' primary='true'>
+      <SourceLine start='34' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
         <Message>At BrowserProperties.java:[lines 34-222]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserProperties</Message>
+      <Message>In class somepackage.utilities.browser.BrowserProperties</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.browser.BrowserProperties' name='setUserAgent' primary='true' signature='(Ljava/lang/String;)V'>
-      <SourceLine endBytecode='64' startBytecode='0' start='63' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='64'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserProperties.setUserAgent(String)</Message>
+    <Method isStatic='false' classname='somepackage.utilities.browser.BrowserProperties' name='setUserAgent' primary='true' signature='(Ljava/lang/String;)V'>
+      <SourceLine endBytecode='64' startBytecode='0' start='63' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='64'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserProperties.setUserAgent(String)</Message>
     </Method>
-    <SourceLine endBytecode='2' startBytecode='2' start='63' classname='com.aconex.utilities.browser.BrowserProperties' primary='true' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='63'>
+    <SourceLine endBytecode='2' startBytecode='2' start='63' classname='somepackage.utilities.browser.BrowserProperties' primary='true' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='63'>
       <Message>At BrowserProperties.java:[line 63]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='e9cbb778c764ba18611328bf751e682f' instanceOccurrenceNum='0' priority='3' abbrev='ES' type='ES_COMPARING_STRINGS_WITH_EQ' instanceOccurrenceMax='0'>
     <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
-    <LongMessage>Comparison of String objects using == or != in com.aconex.utilities.browser.BrowserProperties.setName()
+    <LongMessage>Comparison of String objects using == or != in somepackage.utilities.browser.BrowserProperties.setName()
     </LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserProperties' primary='true'>
-      <SourceLine start='34' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
+    <Class classname='somepackage.utilities.browser.BrowserProperties' primary='true'>
+      <SourceLine start='34' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
         <Message>At BrowserProperties.java:[lines 34-222]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserProperties</Message>
+      <Message>In class somepackage.utilities.browser.BrowserProperties</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.browser.BrowserProperties' name='setName' primary='true' signature='()V'>
-      <SourceLine endBytecode='45' startBytecode='0' start='88' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='101'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserProperties.setName()</Message>
+    <Method isStatic='false' classname='somepackage.utilities.browser.BrowserProperties' name='setName' primary='true' signature='()V'>
+      <SourceLine endBytecode='45' startBytecode='0' start='88' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='101'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserProperties.setName()</Message>
     </Method>
     <Type descriptor='Ljava/lang/String;' role='TYPE_FOUND'>
       <SourceLine start='92' classname='java.lang.String' sourcepath='java/lang/String.java' sourcefile='String.java' end='2973'>
@@ -562,16 +363,16 @@
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
-    <SourceLine endBytecode='6' startBytecode='6' start='88' classname='com.aconex.utilities.browser.BrowserProperties' primary='true' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='88'>
+    <SourceLine endBytecode='6' startBytecode='6' start='88' classname='somepackage.utilities.browser.BrowserProperties' primary='true' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='88'>
       <Message>At BrowserProperties.java:[line 88]</Message>
     </SourceLine>
-    <SourceLine endBytecode='24' startBytecode='24' start='90' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='90'>
+    <SourceLine endBytecode='24' startBytecode='24' start='90' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='90'>
       <Message>Another occurrence at BrowserProperties.java:[line 90]</Message>
     </SourceLine>
-    <SourceLine endBytecode='42' startBytecode='42' start='92' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='92'>
+    <SourceLine endBytecode='42' startBytecode='42' start='92' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='92'>
       <Message>Another occurrence at BrowserProperties.java:[line 92]</Message>
     </SourceLine>
-    <SourceLine endBytecode='82' startBytecode='82' start='96' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='96'>
+    <SourceLine endBytecode='82' startBytecode='82' start='96' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='96'>
       <Message>Another occurrence at BrowserProperties.java:[line 96]</Message>
     </SourceLine>
     <Property name='edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.STATIC_AND_UNKNOWN' value='true'></Property>
@@ -579,17 +380,17 @@
   <BugInstance category='BAD_PRACTICE' instanceHash='2336d7e503ab8b66bd8bfc2cbcc0a2ae' instanceOccurrenceNum='0' priority='3' abbrev='ES' type='ES_COMPARING_STRINGS_WITH_EQ' instanceOccurrenceMax='0'>
     <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
     <LongMessage>Comparison of String objects using == or != in
-      com.aconex.utilities.browser.BrowserProperties.setVersion()
+      somepackage.utilities.browser.BrowserProperties.setVersion()
     </LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserProperties' primary='true'>
-      <SourceLine start='34' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
+    <Class classname='somepackage.utilities.browser.BrowserProperties' primary='true'>
+      <SourceLine start='34' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
         <Message>At BrowserProperties.java:[lines 34-222]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserProperties</Message>
+      <Message>In class somepackage.utilities.browser.BrowserProperties</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.browser.BrowserProperties' name='setVersion' primary='true' signature='()V'>
-      <SourceLine endBytecode='50' startBytecode='0' start='114' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='122'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserProperties.setVersion()</Message>
+    <Method isStatic='false' classname='somepackage.utilities.browser.BrowserProperties' name='setVersion' primary='true' signature='()V'>
+      <SourceLine endBytecode='50' startBytecode='0' start='114' classname='somepackage.utilities.browser.BrowserProperties' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='122'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserProperties.setVersion()</Message>
     </Method>
     <Type descriptor='Ljava/lang/String;' role='TYPE_FOUND'>
       <SourceLine start='92' classname='java.lang.String' sourcepath='java/lang/String.java' sourcefile='String.java' end='2973'>
@@ -597,7 +398,7 @@
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
-    <SourceLine endBytecode='6' startBytecode='6' start='114' classname='com.aconex.utilities.browser.BrowserProperties' primary='true' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='114'>
+    <SourceLine endBytecode='6' startBytecode='6' start='114' classname='somepackage.utilities.browser.BrowserProperties' primary='true' sourcepath='somepackage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='114'>
       <Message>At BrowserProperties.java:[line 114]</Message>
     </SourceLine>
     <Property name='edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.STATIC_AND_UNKNOWN' value='true'></Property>
@@ -605,213 +406,213 @@
   <BugInstance category='I18N' instanceHash='434646ef370f5fe0483988cb6e01db45' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='139' startBytecode='0' start='60' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='75'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_ie' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='139' startBytecode='0' start='60' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='75'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_ie(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='70' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='70'>
+    <SourceLine endBytecode='22' startBytecode='22' start='70' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='70'>
       <Message>At BrowserSniffer.java:[line 70]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='45d59ba7b7f5f6080737550f66bd1065' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='87' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='102'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie_4(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_ie_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='87' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='102'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_ie_4(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='97' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='97'>
+    <SourceLine endBytecode='22' startBytecode='22' start='97' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='97'>
       <Message>At BrowserSniffer.java:[line 97]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='db1c2266ed743a840341d0ede66c9eb6' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='114' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='129'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie_5(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_ie_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='114' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='129'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_ie_5(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='124' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='124'>
+    <SourceLine endBytecode='22' startBytecode='22' start='124' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='124'>
       <Message>At BrowserSniffer.java:[line 124]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='35ed017a63e7e679c93a91f4976f110f' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie_5_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='141' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='156'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie_5_5(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_ie_5_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='141' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='156'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_ie_5_5(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='151' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='151'>
+    <SourceLine endBytecode='22' startBytecode='22' start='151' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='151'>
       <Message>At BrowserSniffer.java:[line 151]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='e58cfa76400f8cc05ff07751d03c5978' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_mozilla' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='191' startBytecode='0' start='183' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='201'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_mozilla(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_mozilla' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='191' startBytecode='0' start='183' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='201'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_mozilla(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='193' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='193'>
+    <SourceLine endBytecode='22' startBytecode='22' start='193' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='193'>
       <Message>At BrowserSniffer.java:[line 193]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='62a48ebb79f66fd63b5069188cd1b48f' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_mozilla_1_3_up' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='218' startBytecode='0' start='214' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='240'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_mozilla_1_3_up(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_mozilla_1_3_up' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='218' startBytecode='0' start='214' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='240'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_mozilla_1_3_up(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='224' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='224'>
+    <SourceLine endBytecode='22' startBytecode='22' start='224' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='224'>
       <Message>At BrowserSniffer.java:[line 224]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='61249ef7ad4252e18b8b8af7f3d9d7d' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ns_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='250' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='265'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ns_4(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_ns_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='250' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='265'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_ns_4(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='260' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='260'>
+    <SourceLine endBytecode='22' startBytecode='22' start='260' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='260'>
       <Message>At BrowserSniffer.java:[line 260]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='2bf6249e3fdf04fa0811caa16aeca12c' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepackage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepackage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_wml' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='139' startBytecode='0' start='290' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_wml(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepackage.utilities.browser.BrowserSniffer' name='is_wml' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='139' startBytecode='0' start='290' classname='somepackage.utilities.browser.BrowserSniffer' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'></SourceLine>
+      <Message>In method somepackage.utilities.browser.BrowserSniffer.is_wml(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='300' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='300'>
+    <SourceLine endBytecode='22' startBytecode='22' start='300' classname='somepackage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepackage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='300'>
       <Message>At BrowserSniffer.java:[line 300]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='SECURITY' instanceHash='5d7a3f985cc0b52663e723a6315706c1' instanceOccurrenceNum='0' priority='3' abbrev='SQL' type='SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE' instanceOccurrenceMax='0'>
     <ShortMessage>Nonconstant string passed to execute method on an SQL statement</ShortMessage>
-    <LongMessage>Method com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
+    <LongMessage>Method somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
       passes a nonconstant String to an execute method on an SQL statement
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true'>
-      <SourceLine start='239' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true'>
+      <SourceLine start='239' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'>
         <Message>At LoggingDriver.java:[lines 239-351]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler</Message>
+      <Message>In class somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' name='execute' primary='true' signature='(Ljava/sql/Connection;Ljava/lang/String;)V'>
-      <SourceLine endBytecode='17' startBytecode='0' start='344' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'></SourceLine>
-      <Message>In method com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
+    <Method isStatic='false' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler' name='execute' primary='true' signature='(Ljava/sql/Connection;Ljava/lang/String;)V'>
+      <SourceLine endBytecode='17' startBytecode='0' start='344' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'></SourceLine>
+      <Message>In method somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
       </Message>
     </Method>
-    <SourceLine endBytecode='11' startBytecode='11' start='347' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='347'>
+    <SourceLine endBytecode='11' startBytecode='11' start='347' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='347'>
       <Message>At LoggingDriver.java:[line 347]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='PERFORMANCE' instanceHash='28cd6f1b56d5733fc52774acc7aa6829' instanceOccurrenceNum='0' priority='2' abbrev='SIC' type='SIC_INNER_SHOULD_BE_STATIC' instanceOccurrenceMax='0'>
     <ShortMessage>Should be a static inner class</ShortMessage>
-    <LongMessage>Should com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler be
+    <LongMessage>Should somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler be
       a _static_ inner class?
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' primary='true'>
-      <SourceLine start='431' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='455'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' primary='true'>
+      <SourceLine start='431' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='455'>
         <Message>At LoggingDriver.java:[lines 431-455]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler
+      <Message>In class somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler
       </Message>
     </Class>
-    <SourceLine start='431' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java' end='455'>
+    <SourceLine start='431' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='somepackage/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java' end='455'>
       <Message>At LoggingDriver.java:[lines 431-455]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='9c8820b5f78e266093334b5a3dad842' instanceOccurrenceNum='0' priority='2' abbrev='NP' type='NP_LOAD_OF_KNOWN_NULL_VALUE' instanceOccurrenceMax='0'>
     <ShortMessage>Load of known null value</ShortMessage>
     <LongMessage>Load of known null value in
-      com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
+      somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
       Method, Object[])
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true'>
-      <SourceLine start='366' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='417'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true'>
+      <SourceLine start='366' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='417'>
         <Message>At LoggingDriver.java:[lines 366-417]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler
+      <Message>In class somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler
       </Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' name='invoke' primary='true' signature='(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;'>
-      <SourceLine endBytecode='93' startBytecode='0' start='375' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='397'></SourceLine>
+    <Method isStatic='false' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' name='invoke' primary='true' signature='(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;'>
+      <SourceLine endBytecode='93' startBytecode='0' start='375' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='397'></SourceLine>
       <Message>In method
-        com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
+        somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
         Method, Object[])
       </Message>
     </Method>
-    <SourceLine endBytecode='125' startBytecode='125' start='387' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='387'>
+    <SourceLine endBytecode='125' startBytecode='125' start='387' classname='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='387'>
       <Message>At LoggingDriver.java:[line 387]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='94bcf06bfd79f5dd103bb7a6bb938892' instanceOccurrenceNum='0' priority='2' abbrev='ODR' type='ODR_OPEN_DATABASE_RESOURCE' instanceOccurrenceMax='0'>
     <ShortMessage>Method may fail to close database resource</ShortMessage>
-    <LongMessage>com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo() may fail to close
+    <LongMessage>somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo() may fail to close
       CallableStatement
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true'>
-      <SourceLine start='463' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='734'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true'>
+      <SourceLine start='463' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='734'>
         <Message>At LoggingDriver.java:[lines 463-734]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor</Message>
+      <Message>In class somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' name='getBlockingInfo' primary='true' signature='()Ljava/util/Map;'>
-      <SourceLine endBytecode='62' startBytecode='0' start='612' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='629'></SourceLine>
-      <Message>In method com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo()</Message>
+    <Method isStatic='false' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor' name='getBlockingInfo' primary='true' signature='()Ljava/util/Map;'>
+      <SourceLine endBytecode='62' startBytecode='0' start='612' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='629'></SourceLine>
+      <Message>In method somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo()</Message>
     </Method>
     <Type descriptor='Ljava/sql/CallableStatement;' role='TYPE_CLOSEIT'>
       <SourceLine classname='java.sql.CallableStatement' sourcepath='java/sql/CallableStatement.java' sourcefile='CallableStatement.java'>
@@ -819,149 +620,149 @@
       </SourceLine>
       <Message>Need to close java.sql.CallableStatement</Message>
     </Type>
-    <SourceLine endBytecode='17' startBytecode='17' start='615' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='615'>
+    <SourceLine endBytecode='17' startBytecode='17' start='615' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='615'>
       <Message>At LoggingDriver.java:[line 615]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='3ba68cb497350c301e4f7a74c85fe4a3' instanceOccurrenceNum='0' priority='3' abbrev='PZLA' type='PZLA_PREFER_ZERO_LENGTH_ARRAYS' instanceOccurrenceMax='0'>
     <ShortMessage>Consider returning a zero length array rather than null</ShortMessage>
     <LongMessage>Should
-      com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
+      somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
       LoggingDriver$LoggingDriverMonitor$WarningFilter) return a zero length array rather than null?
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
-      <SourceLine start='764' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
+      <SourceLine start='764' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
         <Message>At LoggingDriver.java:[lines 764-940]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
+      <Message>In class somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='collectWarningMessages' primary='true' signature='(Ljava/sql/SQLWarning;Lcom/aconex/utilities/db/LoggingDriver$LoggingDriverMonitor$WarningFilter;)[Ljava/lang/String;'>
-      <SourceLine endBytecode='214' startBytecode='0' start='863' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='877'></SourceLine>
+    <Method isStatic='false' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='collectWarningMessages' primary='true' signature='(Ljava/sql/SQLWarning;Lsomepackage/utilities/db/LoggingDriver$LoggingDriverMonitor$WarningFilter;)[Ljava/lang/String;'>
+      <SourceLine endBytecode='214' startBytecode='0' start='863' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='877'></SourceLine>
       <Message>In method
-        com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
+        somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
         LoggingDriver$LoggingDriverMonitor$WarningFilter)
       </Message>
     </Method>
-    <SourceLine endBytecode='5' startBytecode='5' start='864' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='864'>
+    <SourceLine endBytecode='5' startBytecode='5' start='864' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='864'>
       <Message>At LoggingDriver.java:[line 864]</Message>
     </SourceLine>
-    <SourceLine endBytecode='52' startBytecode='52' start='875' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='875'>
+    <SourceLine endBytecode='52' startBytecode='52' start='875' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='875'>
       <Message>At LoggingDriver.java:[line 875]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MT_CORRECTNESS' instanceHash='dc100a165fd98ccc6c063768c0b60131' instanceOccurrenceNum='0' priority='3' abbrev='VO' type='VO_VOLATILE_REFERENCE_TO_ARRAY' instanceOccurrenceMax='0'>
     <ShortMessage>A volatile reference to an array doesn't treat the array elements as volatile</ShortMessage>
-    <LongMessage>com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData is a volatile reference to
+    <LongMessage>somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData is a volatile reference to
       an array; the array elements are non-volatile
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
-      <SourceLine start='764' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
+      <SourceLine start='764' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
         <Message>At LoggingDriver.java:[lines 764-940]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
+      <Message>In class somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
     </Class>
-    <Field isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='cpuData' primary='true' signature='[Ljava/lang/String;'>
-      <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
+    <Field isStatic='false' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='cpuData' primary='true' signature='[Ljava/lang/String;'>
+      <SourceLine classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
         <Message>In LoggingDriver.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData</Message>
+      <Message>Field somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData</Message>
     </Field>
-    <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
+    <SourceLine classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
       <Message>In LoggingDriver.java</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MT_CORRECTNESS' instanceHash='101259f4738574d6cea384cfed745249' instanceOccurrenceNum='0' priority='3' abbrev='VO' type='VO_VOLATILE_REFERENCE_TO_ARRAY' instanceOccurrenceMax='0'>
     <ShortMessage>A volatile reference to an array doesn't treat the array elements as volatile</ShortMessage>
-    <LongMessage>com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData is a volatile reference to
+    <LongMessage>somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData is a volatile reference to
       an array; the array elements are non-volatile
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
-      <SourceLine start='764' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
+    <Class classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
+      <SourceLine start='764' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
         <Message>At LoggingDriver.java:[lines 764-940]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
+      <Message>In class somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
     </Class>
-    <Field isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='ioData' primary='true' signature='[Ljava/lang/String;'>
-      <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
+    <Field isStatic='false' classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='ioData' primary='true' signature='[Ljava/lang/String;'>
+      <SourceLine classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
         <Message>In LoggingDriver.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData</Message>
+      <Message>Field somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData</Message>
     </Field>
-    <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
+    <SourceLine classname='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepackage/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
       <Message>In LoggingDriver.java</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='32b4b89479a45ec3c7f2e49d03fdd5c2' instanceOccurrenceNum='0' priority='2' abbrev='Eq' type='EQ_COMPARETO_USE_OBJECT_EQUALS' instanceOccurrenceMax='0'>
     <ShortMessage>Class defines compareTo(...) and uses Object.equals()</ShortMessage>
-    <LongMessage>com.aconex.utilities.message.Message defines compareTo(Message) and uses Object.equals()</LongMessage>
-    <Class classname='com.aconex.utilities.message.Message' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.message.Message' sourcepath='com/aconex/utilities/message/Message.java' sourcefile='Message.java' end='55'>
+    <LongMessage>somepackage.utilities.message.Message defines compareTo(Message) and uses Object.equals()</LongMessage>
+    <Class classname='somepackage.utilities.message.Message' primary='true'>
+      <SourceLine start='13' classname='somepackage.utilities.message.Message' sourcepath='somepackage/utilities/message/Message.java' sourcefile='Message.java' end='55'>
         <Message>At Message.java:[lines 13-55]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.message.Message</Message>
+      <Message>In class somepackage.utilities.message.Message</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.message.Message' name='compareTo' primary='true' signature='(Lcom/aconex/utilities/message/Message;)I'>
-      <SourceLine endBytecode='63' startBytecode='0' start='55' classname='com.aconex.utilities.message.Message' sourcepath='com/aconex/utilities/message/Message.java' sourcefile='Message.java' end='55'></SourceLine>
-      <Message>In method com.aconex.utilities.message.Message.compareTo(Message)</Message>
+    <Method isStatic='false' classname='somepackage.utilities.message.Message' name='compareTo' primary='true' signature='(Lsomepackage/utilities/message/Message;)I'>
+      <SourceLine endBytecode='63' startBytecode='0' start='55' classname='somepackage.utilities.message.Message' sourcepath='somepackage/utilities/message/Message.java' sourcefile='Message.java' end='55'></SourceLine>
+      <Message>In method somepackage.utilities.message.Message.compareTo(Message)</Message>
     </Method>
-    <SourceLine endBytecode='63' startBytecode='0' start='55' classname='com.aconex.utilities.message.Message' sourcepath='com/aconex/utilities/message/Message.java' synthetic='true' sourcefile='Message.java' end='55'>
+    <SourceLine endBytecode='63' startBytecode='0' start='55' classname='somepackage.utilities.message.Message' sourcepath='somepackage/utilities/message/Message.java' synthetic='true' sourcefile='Message.java' end='55'>
       <Message>At Message.java:[line 55]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='1814726daddb6450c0db73bc4162f85c' instanceOccurrenceNum='0' priority='3' abbrev='ISC' type='ISC_INSTANTIATE_STATIC_CLASS' instanceOccurrenceMax='2'>
     <ShortMessage>Needless instantiation of class that only supplies static methods</ShortMessage>
-    <LongMessage>Method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
+    <LongMessage>Method somepackage.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
       that only supplies static methods
     </LongMessage>
-    <Class classname='com.aconex.velocity.VelocityUtils' primary='true'>
-      <SourceLine start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
+    <Class classname='somepackage.velocity.VelocityUtils' primary='true'>
+      <SourceLine start='20' classname='somepackage.velocity.VelocityUtils' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
         <Message>At VelocityUtils.java:[lines 20-74]</Message>
       </SourceLine>
-      <Message>In class com.aconex.velocity.VelocityUtils</Message>
+      <Message>In class somepackage.velocity.VelocityUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
-      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
-      <Message>In method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
+    <Method isStatic='true' classname='somepackage.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
+      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='somepackage.velocity.VelocityUtils' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
+      <Message>In method somepackage.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
     </Method>
-    <SourceLine endBytecode='173' startBytecode='173' start='48' classname='com.aconex.velocity.VelocityUtils' primary='true' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='48'>
+    <SourceLine endBytecode='173' startBytecode='173' start='48' classname='somepackage.velocity.VelocityUtils' primary='true' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='48'>
       <Message>At VelocityUtils.java:[line 48]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='1814726daddb6450c0db73bc4162f85c' instanceOccurrenceNum='1' priority='3' abbrev='ISC' type='ISC_INSTANTIATE_STATIC_CLASS' instanceOccurrenceMax='2'>
     <ShortMessage>Needless instantiation of class that only supplies static methods</ShortMessage>
-    <LongMessage>Method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
+    <LongMessage>Method somepackage.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
       that only supplies static methods
     </LongMessage>
-    <Class classname='com.aconex.velocity.VelocityUtils' primary='true'>
-      <SourceLine start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
+    <Class classname='somepackage.velocity.VelocityUtils' primary='true'>
+      <SourceLine start='20' classname='somepackage.velocity.VelocityUtils' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
         <Message>At VelocityUtils.java:[lines 20-74]</Message>
       </SourceLine>
-      <Message>In class com.aconex.velocity.VelocityUtils</Message>
+      <Message>In class somepackage.velocity.VelocityUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
-      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
-      <Message>In method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
+    <Method isStatic='true' classname='somepackage.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
+      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='somepackage.velocity.VelocityUtils' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
+      <Message>In method somepackage.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
     </Method>
-    <SourceLine endBytecode='191' startBytecode='191' start='49' classname='com.aconex.velocity.VelocityUtils' primary='true' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='49'>
+    <SourceLine endBytecode='191' startBytecode='191' start='49' classname='somepackage.velocity.VelocityUtils' primary='true' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='49'>
       <Message>At VelocityUtils.java:[line 49]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='1814726daddb6450c0db73bc4162f85c' instanceOccurrenceNum='2' priority='3' abbrev='ISC' type='ISC_INSTANTIATE_STATIC_CLASS' instanceOccurrenceMax='2'>
     <ShortMessage>Needless instantiation of class that only supplies static methods</ShortMessage>
-    <LongMessage>Method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
+    <LongMessage>Method somepackage.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
       that only supplies static methods
     </LongMessage>
-    <Class classname='com.aconex.velocity.VelocityUtils' primary='true'>
-      <SourceLine start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
+    <Class classname='somepackage.velocity.VelocityUtils' primary='true'>
+      <SourceLine start='20' classname='somepackage.velocity.VelocityUtils' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
         <Message>At VelocityUtils.java:[lines 20-74]</Message>
       </SourceLine>
-      <Message>In class com.aconex.velocity.VelocityUtils</Message>
+      <Message>In class somepackage.velocity.VelocityUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
-      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
-      <Message>In method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
+    <Method isStatic='true' classname='somepackage.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
+      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='somepackage.velocity.VelocityUtils' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
+      <Message>In method somepackage.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
     </Method>
-    <SourceLine endBytecode='209' startBytecode='209' start='50' classname='com.aconex.velocity.VelocityUtils' primary='true' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='50'>
+    <SourceLine endBytecode='209' startBytecode='209' start='50' classname='somepackage.velocity.VelocityUtils' primary='true' sourcepath='somepackage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='50'>
       <Message>At VelocityUtils.java:[line 50]</Message>
     </SourceLine>
   </BugInstance>
@@ -1291,273 +1092,273 @@
     <MissingClass>org.apache.commons.discovery.tools.DiscoverClass</MissingClass>
   </Errors>
   <FindBugsSummary alloc_mbytes='1365.38' priority_2='11' priority_1='3' gc_seconds='0.15' peak_mbytes='395.80' total_bugs='37' priority_3='23' referenced_classes='507' timestamp='Mon, 23 Aug 2010 16:39:40 +1000' total_classes='135' num_packages='19' total_size='3444' cpu_seconds='26.16' clock_seconds='8.91' vm_version='16.3-b01'>
-    <FileStats path='com/aconex/db/BulkOperationHandler.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/db/CompositeBulkOperationHandler.java' bugCount='0' size='26'></FileStats>
-    <FileStats path='com/aconex/db/DAO.java' bugCount='0' size='19'></FileStats>
-    <FileStats path='com/aconex/db/DatabaseConstants.java' bugCount='0' size='5'></FileStats>
-    <FileStats path='com/aconex/db/HibernateDAO.java' bugCount='0' size='295'></FileStats>
-    <FileStats path='com/aconex/db/JdbcDAO.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/db/JdbcSettingsMBean.java' bugCount='1' bugHash='c5e12ef8b4c3b5761631ee80aa03ba0a' size='20'></FileStats>
-    <FileStats path='com/aconex/db/KeyedPersistable.java' bugCount='0' size='2'></FileStats>
-    <FileStats path='com/aconex/db/LegacyHibernateFlushingDAO.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/db/LegacyService.java' bugCount='2' bugHash='12e55d926b38eb819d258c757ff8842d' size='73'></FileStats>
-    <FileStats path='com/aconex/db/OrderDirection.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/AconexInExpression.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/AconexLikeExpression.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/BaseInExpression.java' bugCount='1' bugHash='f98a9b1e595d46d6770b05fae4ec7e9a' size='35'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernateBulkOperationHandler.java' bugCount='0' size='58'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernateCallbackWithoutResult.java' bugCount='0' size='7'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernateKeyEqualityHelper.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernatePausingBulkOperationHandler.java' bugCount='0' size='20'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/IdentifierInExpression.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/NativeSQLOrder.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/OptionalRestrictions.java' bugCount='0' size='33'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/OrderingUtils.java' bugCount='0' size='7'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/Restrictions.java' bugCount='0' size='89'></FileStats>
-    <FileStats path='com/aconex/db/usertypes/KeyedEnumUserType.java' bugCount='1' bugHash='29ebc0e6cf8b9d964eead37d91cb6702' size='66'></FileStats>
-    <FileStats path='com/aconex/db/usertypes/XStreamUserType.java' bugCount='1' bugHash='c02a68e22c20663da99cecc766d4673c' size='37'></FileStats>
-    <FileStats path='com/aconex/lockable/Lockable.java' bugCount='0' size='7'></FileStats>
-    <FileStats path='com/aconex/lockable/LockableSupport.java' bugCount='1' bugHash='84009006b1915ceafcb90f3f55754296' size='29'></FileStats>
-    <FileStats path='com/aconex/lockable/LockedException.java' bugCount='0' size='8'></FileStats>
-    <FileStats path='com/aconex/monitoring/MonitoredBeanPredicates.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/monitoring/RequestId.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/monitoring/TimedRunnable.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/pdf/jobTicket/XMLElement.java' bugCount='2' bugHash='b6186363a00367c77f5236cff985d159' size='68'></FileStats>
-    <FileStats path='com/aconex/security/util/PhoneticUtils.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/specification/OrSpecification.java' bugCount='0' size='10'></FileStats>
-    <FileStats path='com/aconex/specification/Specification.java' bugCount='0' size='2'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/CollectionMatchers.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsAnnotatedWithMatcher.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsCollectionContainingInAnyOrderMatcher.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsDeeplySerializableMatcher.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsImmutableMatcher.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsListContainingInOrderMatcher.java' bugCount='0' size='17'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsListEmptyMatcher.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsMapEmptyMatcher.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsMemberPackageProtectedMatcher.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsMemberPublicMatcher.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsOfLengthMatcher.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsTransactionalMatcher.java' bugCount='0' size='30'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsUrlMatcher.java' bugCount='0' size='23'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/MapContainsEntriesMatcher.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/MatchesRegexMatcher.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/ReflectionMatchers.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/StringMatchers.java' bugCount='0' size='8'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/TransactionalMatchers.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/UrlMatchers.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/test/mockito/ReflectionMatchers.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/test/mockito/StringMatchers.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/utilities/AnnotationEqualityHelper.java' bugCount='0' size='111'></FileStats>
-    <FileStats path='com/aconex/utilities/ArgumentValidator.java' bugCount='0' size='41'></FileStats>
-    <FileStats path='com/aconex/utilities/BeanUtils.java' bugCount='1' bugHash='57903c4cd534a91c3276cfdc1fd68481' size='9'></FileStats>
-    <FileStats path='com/aconex/utilities/ConfigConstants.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/utilities/CryptographyException.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/utilities/DataManipulation.java' bugCount='0' size='92'></FileStats>
-    <FileStats path='com/aconex/utilities/EnumUtils.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/utilities/EqualityField.java' bugCount='0' size='1'></FileStats>
-    <FileStats path='com/aconex/utilities/FormUtils.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/utilities/GuidGenerator.java' bugCount='0' size='5'></FileStats>
-    <FileStats path='com/aconex/utilities/HTMLFormat.java' bugCount='0' size='56'></FileStats>
-    <FileStats path='com/aconex/utilities/HTMLFormatRules.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/utilities/JMXUtils.java' bugCount='0' size='25'></FileStats>
-    <FileStats path='com/aconex/utilities/NumberUtils.java' bugCount='1' bugHash='61c1c3f5ce459cc689664af48d0d4937' size='10'></FileStats>
-    <FileStats path='com/aconex/utilities/SHA1.java' bugCount='0' size='199'></FileStats>
-    <FileStats path='com/aconex/utilities/StringEscapeUtils.java' bugCount='1' bugHash='57c340add2bc35c912e992f3563bcc49' size='13'></FileStats>
-    <FileStats path='com/aconex/utilities/StringTrimingUtils.java' bugCount='0' size='20'></FileStats>
-    <FileStats path='com/aconex/utilities/TimingStatistics.java' bugCount='1' bugHash='d1af948812058a7cc55e1db4b430f739' size='49'></FileStats>
-    <FileStats path='com/aconex/utilities/TransientHolder.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/utilities/URLUtils.java' bugCount='1' bugHash='4052709d5c28d2a20b24f26c3de7b610' size='137'></FileStats>
-    <FileStats path='com/aconex/utilities/ValidationUtils.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/utilities/XMLUtils.java' bugCount='1' bugHash='35317315f7ba8f065bf25d8d053ab644' size='26'></FileStats>
-    <FileStats path='com/aconex/utilities/XStreamUtils.java' bugCount='0' size='24'></FileStats>
-    <FileStats path='com/aconex/utilities/browser/BrowserProperties.java' bugCount='3' bugHash='2c246e8b51cb9ef542b03f352e0eb65f' size='120'></FileStats>
-    <FileStats path='com/aconex/utilities/browser/BrowserSniffer.java' bugCount='8' bugHash='34c025ada75d51e089cffd88dcd045a7' size='115'></FileStats>
-    <FileStats path='com/aconex/utilities/db/ConnectionIdSource.java' bugCount='0' size='29'></FileStats>
-    <FileStats path='com/aconex/utilities/db/LoggingDriver.java' bugCount='7' bugHash='553a0de7c357f4c0f8f14ec7c2a7b861' size='560'></FileStats>
-    <FileStats path='com/aconex/utilities/db/MDCLoggerDataSource.java' bugCount='0' size='41'></FileStats>
-    <FileStats path='com/aconex/utilities/db/SQLServerUtils.java' bugCount='0' size='21'></FileStats>
-    <FileStats path='com/aconex/utilities/decorators/AbstractDecorator.java' bugCount='0' size='8'></FileStats>
-    <FileStats path='com/aconex/utilities/decorators/AbstractRunnableDecorator.java' bugCount='0' size='4'></FileStats>
-    <FileStats path='com/aconex/utilities/decorators/Decorator.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/utilities/encoder/DigestUtils.java' bugCount='0' size='21'></FileStats>
-    <FileStats path='com/aconex/utilities/message/Message.java' bugCount='1' bugHash='1ca3517a1b6a4b2befa7a4eed133e621' size='35'></FileStats>
-    <FileStats path='com/aconex/utilities/message/MessageContainer.java' bugCount='0' size='60'></FileStats>
-    <FileStats path='com/aconex/utilities/message/MessageType.java' bugCount='0' size='23'></FileStats>
-    <FileStats path='com/aconex/utilities/tuples/Pair.java' bugCount='0' size='67'></FileStats>
-    <FileStats path='com/aconex/utilities/web/binding/editors/AbstractPropertyEditor.java' bugCount='0' size='22'></FileStats>
-    <FileStats path='com/aconex/velocity/VelocityUtils.java' bugCount='3' bugHash='6d4bb5d9a4f2f02a60a26dc816f71a93' size='36'></FileStats>
-    <PackageStats priority_2='1' total_size='495' package='com.aconex.db' total_bugs='3' priority_3='2' total_types='22'>
-      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='com.aconex.db.BulkOperationHandler' interface='true' size='7'></ClassStats>
-      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='com.aconex.db.BulkOperationHandler$1' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='CompositeBulkOperationHandler.java' bugs='0' class='com.aconex.db.CompositeBulkOperationHandler' interface='false' size='26'></ClassStats>
-      <ClassStats sourceFile='DAO.java' bugs='0' class='com.aconex.db.DAO' interface='true' size='8'></ClassStats>
-      <ClassStats sourceFile='DAO.java' bugs='0' class='com.aconex.db.DAO$ObjectRetrievalState' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='DatabaseConstants.java' bugs='0' class='com.aconex.db.DatabaseConstants' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO' interface='false' size='103'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$1' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$2' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$3' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$4' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$5' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$Alias' interface='false' size='20'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$CriteriaSearch' interface='false' size='97'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$CriteriaSearchCallback' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$JoinType' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='JdbcDAO.java' bugs='0' class='com.aconex.db.JdbcDAO' interface='false' size='16'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='JdbcSettingsMBean.java' bugs='1' class='com.aconex.db.JdbcSettingsMBean' interface='false' size='20'></ClassStats>
-      <ClassStats sourceFile='KeyedPersistable.java' bugs='0' class='com.aconex.db.KeyedPersistable' interface='true' size='2'></ClassStats>
-      <ClassStats sourceFile='LegacyHibernateFlushingDAO.java' bugs='0' class='com.aconex.db.LegacyHibernateFlushingDAO' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='LegacyService.java' bugs='2' class='com.aconex.db.LegacyService' interface='false' priority_3='2' size='73'></ClassStats>
-      <ClassStats sourceFile='OrderDirection.java' bugs='0' class='com.aconex.db.OrderDirection' interface='false' size='11'></ClassStats>
+    <FileStats path='somepackage/db/BulkOperationHandler.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepackage/db/CompositeBulkOperationHandler.java' bugCount='0' size='26'></FileStats>
+    <FileStats path='somepackage/db/DAO.java' bugCount='0' size='19'></FileStats>
+    <FileStats path='somepackage/db/DatabaseConstants.java' bugCount='0' size='5'></FileStats>
+    <FileStats path='somepackage/db/HibernateDAO.java' bugCount='0' size='295'></FileStats>
+    <FileStats path='somepackage/db/JdbcDAO.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepackage/db/JdbcSettingsMBean.java' bugCount='1' bugHash='c5e12ef8b4c3b5761631ee80aa03ba0a' size='20'></FileStats>
+    <FileStats path='somepackage/db/KeyedPersistable.java' bugCount='0' size='2'></FileStats>
+    <FileStats path='somepackage/db/LegacyHibernateFlushingDAO.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/db/LegacyService.java' bugCount='2' bugHash='12e55d926b38eb819d258c757ff8842d' size='73'></FileStats>
+    <FileStats path='somepackage/db/OrderDirection.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepackage/db/hibernate/InExpression.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepackage/db/hibernate/LikeExpression.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/db/hibernate/BaseInExpression.java' bugCount='1' bugHash='f98a9b1e595d46d6770b05fae4ec7e9a' size='35'></FileStats>
+    <FileStats path='somepackage/db/hibernate/HibernateBulkOperationHandler.java' bugCount='0' size='58'></FileStats>
+    <FileStats path='somepackage/db/hibernate/HibernateCallbackWithoutResult.java' bugCount='0' size='7'></FileStats>
+    <FileStats path='somepackage/db/hibernate/HibernateKeyEqualityHelper.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/db/hibernate/HibernatePausingBulkOperationHandler.java' bugCount='0' size='20'></FileStats>
+    <FileStats path='somepackage/db/hibernate/IdentifierInExpression.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepackage/db/hibernate/NativeSQLOrder.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepackage/db/hibernate/OptionalRestrictions.java' bugCount='0' size='33'></FileStats>
+    <FileStats path='somepackage/db/hibernate/OrderingUtils.java' bugCount='0' size='7'></FileStats>
+    <FileStats path='somepackage/db/hibernate/Restrictions.java' bugCount='0' size='89'></FileStats>
+    <FileStats path='somepackage/db/usertypes/KeyedEnumUserType.java' bugCount='1' bugHash='29ebc0e6cf8b9d964eead37d91cb6702' size='66'></FileStats>
+    <FileStats path='somepackage/db/usertypes/XStreamUserType.java' bugCount='1' bugHash='c02a68e22c20663da99cecc766d4673c' size='37'></FileStats>
+    <FileStats path='somepackage/lockable/Lockable.java' bugCount='0' size='7'></FileStats>
+    <FileStats path='somepackage/lockable/LockableSupport.java' bugCount='1' bugHash='84009006b1915ceafcb90f3f55754296' size='29'></FileStats>
+    <FileStats path='somepackage/lockable/LockedException.java' bugCount='0' size='8'></FileStats>
+    <FileStats path='somepackage/monitoring/MonitoredBeanPredicates.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepackage/monitoring/RequestId.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepackage/monitoring/TimedRunnable.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepackage/pdf/jobTicket/XMLElement.java' bugCount='2' bugHash='b6186363a00367c77f5236cff985d159' size='68'></FileStats>
+    <FileStats path='somepackage/security/util/PhoneticUtils.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/specification/OrSpecification.java' bugCount='0' size='10'></FileStats>
+    <FileStats path='somepackage/specification/Specification.java' bugCount='0' size='2'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/CollectionMatchers.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsAnnotatedWithMatcher.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsCollectionContainingInAnyOrderMatcher.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsDeeplySerializableMatcher.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsImmutableMatcher.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsListContainingInOrderMatcher.java' bugCount='0' size='17'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsListEmptyMatcher.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsMapEmptyMatcher.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsMemberPackageProtectedMatcher.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsMemberPublicMatcher.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsOfLengthMatcher.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsTransactionalMatcher.java' bugCount='0' size='30'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/IsUrlMatcher.java' bugCount='0' size='23'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/MapContainsEntriesMatcher.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/MatchesRegexMatcher.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/ReflectionMatchers.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/StringMatchers.java' bugCount='0' size='8'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/TransactionalMatchers.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepackage/test/hamcrest/UrlMatchers.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepackage/test/mockito/ReflectionMatchers.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepackage/test/mockito/StringMatchers.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepackage/utilities/AnnotationEqualityHelper.java' bugCount='0' size='111'></FileStats>
+    <FileStats path='somepackage/utilities/ArgumentValidator.java' bugCount='0' size='41'></FileStats>
+    <FileStats path='somepackage/utilities/BeanUtils.java' bugCount='1' bugHash='57903c4cd534a91c3276cfdc1fd68481' size='9'></FileStats>
+    <FileStats path='somepackage/utilities/ConfigConstants.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepackage/utilities/CryptographyException.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepackage/utilities/DataManipulation.java' bugCount='0' size='92'></FileStats>
+    <FileStats path='somepackage/utilities/EnumUtils.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/utilities/EqualityField.java' bugCount='0' size='1'></FileStats>
+    <FileStats path='somepackage/utilities/FormUtils.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepackage/utilities/GuidGenerator.java' bugCount='0' size='5'></FileStats>
+    <FileStats path='somepackage/utilities/HTMLFormat.java' bugCount='0' size='56'></FileStats>
+    <FileStats path='somepackage/utilities/HTMLFormatRules.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepackage/utilities/JMXUtils.java' bugCount='0' size='25'></FileStats>
+    <FileStats path='somepackage/utilities/NumberUtils.java' bugCount='1' bugHash='61c1c3f5ce459cc689664af48d0d4937' size='10'></FileStats>
+    <FileStats path='somepackage/utilities/SHA1.java' bugCount='0' size='199'></FileStats>
+    <FileStats path='somepackage/utilities/StringEscapeUtils.java' bugCount='1' bugHash='57c340add2bc35c912e992f3563bcc49' size='13'></FileStats>
+    <FileStats path='somepackage/utilities/StringTrimingUtils.java' bugCount='0' size='20'></FileStats>
+    <FileStats path='somepackage/utilities/TimingStatistics.java' bugCount='1' bugHash='d1af948812058a7cc55e1db4b430f739' size='49'></FileStats>
+    <FileStats path='somepackage/utilities/TransientHolder.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepackage/utilities/URLUtils.java' bugCount='1' bugHash='4052709d5c28d2a20b24f26c3de7b610' size='137'></FileStats>
+    <FileStats path='somepackage/utilities/ValidationUtils.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepackage/utilities/XMLUtils.java' bugCount='1' bugHash='35317315f7ba8f065bf25d8d053ab644' size='26'></FileStats>
+    <FileStats path='somepackage/utilities/XStreamUtils.java' bugCount='0' size='24'></FileStats>
+    <FileStats path='somepackage/utilities/browser/BrowserProperties.java' bugCount='3' bugHash='2c246e8b51cb9ef542b03f352e0eb65f' size='120'></FileStats>
+    <FileStats path='somepackage/utilities/browser/BrowserSniffer.java' bugCount='8' bugHash='34c025ada75d51e089cffd88dcd045a7' size='115'></FileStats>
+    <FileStats path='somepackage/utilities/db/ConnectionIdSource.java' bugCount='0' size='29'></FileStats>
+    <FileStats path='somepackage/utilities/db/LoggingDriver.java' bugCount='7' bugHash='553a0de7c357f4c0f8f14ec7c2a7b861' size='560'></FileStats>
+    <FileStats path='somepackage/utilities/db/MDCLoggerDataSource.java' bugCount='0' size='41'></FileStats>
+    <FileStats path='somepackage/utilities/db/SQLServerUtils.java' bugCount='0' size='21'></FileStats>
+    <FileStats path='somepackage/utilities/decorators/AbstractDecorator.java' bugCount='0' size='8'></FileStats>
+    <FileStats path='somepackage/utilities/decorators/AbstractRunnableDecorator.java' bugCount='0' size='4'></FileStats>
+    <FileStats path='somepackage/utilities/decorators/Decorator.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepackage/utilities/encoder/DigestUtils.java' bugCount='0' size='21'></FileStats>
+    <FileStats path='somepackage/utilities/message/Message.java' bugCount='1' bugHash='1ca3517a1b6a4b2befa7a4eed133e621' size='35'></FileStats>
+    <FileStats path='somepackage/utilities/message/MessageContainer.java' bugCount='0' size='60'></FileStats>
+    <FileStats path='somepackage/utilities/message/MessageType.java' bugCount='0' size='23'></FileStats>
+    <FileStats path='somepackage/utilities/tuples/Pair.java' bugCount='0' size='67'></FileStats>
+    <FileStats path='somepackage/utilities/web/binding/editors/AbstractPropertyEditor.java' bugCount='0' size='22'></FileStats>
+    <FileStats path='somepackage/velocity/VelocityUtils.java' bugCount='3' bugHash='6d4bb5d9a4f2f02a60a26dc816f71a93' size='36'></FileStats>
+    <PackageStats priority_2='1' total_size='495' package='somepackage.db' total_bugs='3' priority_3='2' total_types='22'>
+      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='somepackage.db.BulkOperationHandler' interface='true' size='7'></ClassStats>
+      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='somepackage.db.BulkOperationHandler$1' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='CompositeBulkOperationHandler.java' bugs='0' class='somepackage.db.CompositeBulkOperationHandler' interface='false' size='26'></ClassStats>
+      <ClassStats sourceFile='DAO.java' bugs='0' class='somepackage.db.DAO' interface='true' size='8'></ClassStats>
+      <ClassStats sourceFile='DAO.java' bugs='0' class='somepackage.db.DAO$ObjectRetrievalState' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='DatabaseConstants.java' bugs='0' class='somepackage.db.DatabaseConstants' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO' interface='false' size='103'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$1' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$2' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$3' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$4' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$5' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$Alias' interface='false' size='20'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$CriteriaSearch' interface='false' size='97'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$CriteriaSearchCallback' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepackage.db.HibernateDAO$JoinType' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='JdbcDAO.java' bugs='0' class='somepackage.db.JdbcDAO' interface='false' size='16'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='JdbcSettingsMBean.java' bugs='1' class='somepackage.db.JdbcSettingsMBean' interface='false' size='20'></ClassStats>
+      <ClassStats sourceFile='KeyedPersistable.java' bugs='0' class='somepackage.db.KeyedPersistable' interface='true' size='2'></ClassStats>
+      <ClassStats sourceFile='LegacyHibernateFlushingDAO.java' bugs='0' class='somepackage.db.LegacyHibernateFlushingDAO' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='LegacyService.java' bugs='2' class='somepackage.db.LegacyService' interface='false' priority_3='2' size='73'></ClassStats>
+      <ClassStats sourceFile='OrderDirection.java' bugs='0' class='somepackage.db.OrderDirection' interface='false' size='11'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='1' total_size='309' package='com.aconex.db.hibernate' total_bugs='1' total_types='17'>
-      <ClassStats sourceFile='AconexInExpression.java' bugs='0' class='com.aconex.db.hibernate.AconexInExpression' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='AconexLikeExpression.java' bugs='0' class='com.aconex.db.hibernate.AconexLikeExpression' interface='false' size='12'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='BaseInExpression.java' bugs='1' class='com.aconex.db.hibernate.BaseInExpression' interface='false' size='35'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler' interface='false' size='31'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$1' interface='false' size='1'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$SessionOperation' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$SessionOperation$1' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$SessionOperation$2' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='HibernateCallbackWithoutResult.java' bugs='0' class='com.aconex.db.hibernate.HibernateCallbackWithoutResult' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='HibernateKeyEqualityHelper.java' bugs='0' class='com.aconex.db.hibernate.HibernateKeyEqualityHelper' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernatePausingBulkOperationHandler' interface='false' size='15'></ClassStats>
-      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernatePausingBulkOperationHandler$TransactionInProgressException' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='IdentifierInExpression.java' bugs='0' class='com.aconex.db.hibernate.IdentifierInExpression' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='NativeSQLOrder.java' bugs='0' class='com.aconex.db.hibernate.NativeSQLOrder' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='OptionalRestrictions.java' bugs='0' class='com.aconex.db.hibernate.OptionalRestrictions' interface='false' size='33'></ClassStats>
-      <ClassStats sourceFile='OrderingUtils.java' bugs='0' class='com.aconex.db.hibernate.OrderingUtils' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='Restrictions.java' bugs='0' class='com.aconex.db.hibernate.Restrictions' interface='false' size='89'></ClassStats>
+    <PackageStats priority_2='1' total_size='309' package='somepackage.db.hibernate' total_bugs='1' total_types='17'>
+      <ClassStats sourceFile='InExpression.java' bugs='0' class='somepackage.db.hibernate.InExpression' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='LikeExpression.java' bugs='0' class='somepackage.db.hibernate.LikeExpression' interface='false' size='12'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='BaseInExpression.java' bugs='1' class='somepackage.db.hibernate.BaseInExpression' interface='false' size='35'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernateBulkOperationHandler' interface='false' size='31'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernateBulkOperationHandler$1' interface='false' size='1'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernateBulkOperationHandler$SessionOperation' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernateBulkOperationHandler$SessionOperation$1' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernateBulkOperationHandler$SessionOperation$2' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='HibernateCallbackWithoutResult.java' bugs='0' class='somepackage.db.hibernate.HibernateCallbackWithoutResult' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='HibernateKeyEqualityHelper.java' bugs='0' class='somepackage.db.hibernate.HibernateKeyEqualityHelper' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernatePausingBulkOperationHandler' interface='false' size='15'></ClassStats>
+      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='somepackage.db.hibernate.HibernatePausingBulkOperationHandler$TransactionInProgressException' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='IdentifierInExpression.java' bugs='0' class='somepackage.db.hibernate.IdentifierInExpression' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='NativeSQLOrder.java' bugs='0' class='somepackage.db.hibernate.NativeSQLOrder' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='OptionalRestrictions.java' bugs='0' class='somepackage.db.hibernate.OptionalRestrictions' interface='false' size='33'></ClassStats>
+      <ClassStats sourceFile='OrderingUtils.java' bugs='0' class='somepackage.db.hibernate.OrderingUtils' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='Restrictions.java' bugs='0' class='somepackage.db.hibernate.Restrictions' interface='false' size='89'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='2' total_size='103' package='com.aconex.db.usertypes' total_bugs='2' total_types='2'>
-      <ClassStats priority_2='1' sourceFile='KeyedEnumUserType.java' bugs='1' class='com.aconex.db.usertypes.KeyedEnumUserType' interface='false' size='66'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='XStreamUserType.java' bugs='1' class='com.aconex.db.usertypes.XStreamUserType' interface='false' size='37'></ClassStats>
+    <PackageStats priority_2='2' total_size='103' package='somepackage.db.usertypes' total_bugs='2' total_types='2'>
+      <ClassStats priority_2='1' sourceFile='KeyedEnumUserType.java' bugs='1' class='somepackage.db.usertypes.KeyedEnumUserType' interface='false' size='66'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='XStreamUserType.java' bugs='1' class='somepackage.db.usertypes.XStreamUserType' interface='false' size='37'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='44' package='com.aconex.lockable' total_bugs='1' priority_3='1' total_types='3'>
-      <ClassStats sourceFile='Lockable.java' bugs='0' class='com.aconex.lockable.Lockable' interface='true' size='7'></ClassStats>
-      <ClassStats sourceFile='LockableSupport.java' bugs='1' class='com.aconex.lockable.LockableSupport' interface='false' priority_3='1' size='29'></ClassStats>
-      <ClassStats sourceFile='LockedException.java' bugs='0' class='com.aconex.lockable.LockedException' interface='false' size='8'></ClassStats>
+    <PackageStats total_size='44' package='somepackage.lockable' total_bugs='1' priority_3='1' total_types='3'>
+      <ClassStats sourceFile='Lockable.java' bugs='0' class='somepackage.lockable.Lockable' interface='true' size='7'></ClassStats>
+      <ClassStats sourceFile='LockableSupport.java' bugs='1' class='somepackage.lockable.LockableSupport' interface='false' priority_3='1' size='29'></ClassStats>
+      <ClassStats sourceFile='LockedException.java' bugs='0' class='somepackage.lockable.LockedException' interface='false' size='8'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='33' package='com.aconex.monitoring' total_bugs='0' total_types='3'>
-      <ClassStats sourceFile='MonitoredBeanPredicates.java' bugs='0' class='com.aconex.monitoring.MonitoredBeanPredicates' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='RequestId.java' bugs='0' class='com.aconex.monitoring.RequestId' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='TimedRunnable.java' bugs='0' class='com.aconex.monitoring.TimedRunnable' interface='false' size='18'></ClassStats>
+    <PackageStats total_size='33' package='somepackage.monitoring' total_bugs='0' total_types='3'>
+      <ClassStats sourceFile='MonitoredBeanPredicates.java' bugs='0' class='somepackage.monitoring.MonitoredBeanPredicates' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='RequestId.java' bugs='0' class='somepackage.monitoring.RequestId' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='TimedRunnable.java' bugs='0' class='somepackage.monitoring.TimedRunnable' interface='false' size='18'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='2' total_size='68' package='com.aconex.pdf.jobTicket' total_bugs='2' total_types='2'>
-      <ClassStats sourceFile='XMLElement.java' bugs='0' class='com.aconex.pdf.jobTicket.XMLElement' interface='false' size='50'></ClassStats>
-      <ClassStats priority_2='2' sourceFile='XMLElement.java' bugs='2' class='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' interface='false' size='18'></ClassStats>
+    <PackageStats priority_2='2' total_size='68' package='somepackage.pdf.jobTicket' total_bugs='2' total_types='2'>
+      <ClassStats sourceFile='XMLElement.java' bugs='0' class='somepackage.pdf.jobTicket.XMLElement' interface='false' size='50'></ClassStats>
+      <ClassStats priority_2='2' sourceFile='XMLElement.java' bugs='2' class='somepackage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' interface='false' size='18'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='12' package='com.aconex.security.util' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='PhoneticUtils.java' bugs='0' class='com.aconex.security.util.PhoneticUtils' interface='false' size='12'></ClassStats>
+    <PackageStats total_size='12' package='somepackage.security.util' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='PhoneticUtils.java' bugs='0' class='somepackage.security.util.PhoneticUtils' interface='false' size='12'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='12' package='com.aconex.specification' total_bugs='0' total_types='2'>
-      <ClassStats sourceFile='OrSpecification.java' bugs='0' class='com.aconex.specification.OrSpecification' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='Specification.java' bugs='0' class='com.aconex.specification.Specification' interface='true' size='2'></ClassStats>
+    <PackageStats total_size='12' package='somepackage.specification' total_bugs='0' total_types='2'>
+      <ClassStats sourceFile='OrSpecification.java' bugs='0' class='somepackage.specification.OrSpecification' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='Specification.java' bugs='0' class='somepackage.specification.Specification' interface='true' size='2'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='264' package='com.aconex.test.hamcrest' total_bugs='0' total_types='19'>
-      <ClassStats sourceFile='CollectionMatchers.java' bugs='0' class='com.aconex.test.hamcrest.CollectionMatchers' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='IsAnnotatedWithMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsAnnotatedWithMatcher' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='IsCollectionContainingInAnyOrderMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsCollectionContainingInAnyOrderMatcher' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='IsDeeplySerializableMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsDeeplySerializableMatcher' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='IsImmutableMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsImmutableMatcher' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='IsListContainingInOrderMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsListContainingInOrderMatcher' interface='false' size='17'></ClassStats>
-      <ClassStats sourceFile='IsListEmptyMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsListEmptyMatcher' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='IsMapEmptyMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsMapEmptyMatcher' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='IsMemberPackageProtectedMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsMemberPackageProtectedMatcher' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='IsMemberPublicMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsMemberPublicMatcher' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='IsOfLengthMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsOfLengthMatcher' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='IsTransactionalMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsTransactionalMatcher' interface='false' size='30'></ClassStats>
-      <ClassStats sourceFile='IsUrlMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsUrlMatcher' interface='false' size='23'></ClassStats>
-      <ClassStats sourceFile='MapContainsEntriesMatcher.java' bugs='0' class='com.aconex.test.hamcrest.MapContainsEntriesMatcher' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='MatchesRegexMatcher.java' bugs='0' class='com.aconex.test.hamcrest.MatchesRegexMatcher' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='com.aconex.test.hamcrest.ReflectionMatchers' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='com.aconex.test.hamcrest.StringMatchers' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='TransactionalMatchers.java' bugs='0' class='com.aconex.test.hamcrest.TransactionalMatchers' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='UrlMatchers.java' bugs='0' class='com.aconex.test.hamcrest.UrlMatchers' interface='false' size='6'></ClassStats>
+    <PackageStats total_size='264' package='somepackage.test.hamcrest' total_bugs='0' total_types='19'>
+      <ClassStats sourceFile='CollectionMatchers.java' bugs='0' class='somepackage.test.hamcrest.CollectionMatchers' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='IsAnnotatedWithMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsAnnotatedWithMatcher' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='IsCollectionContainingInAnyOrderMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsCollectionContainingInAnyOrderMatcher' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='IsDeeplySerializableMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsDeeplySerializableMatcher' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='IsImmutableMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsImmutableMatcher' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='IsListContainingInOrderMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsListContainingInOrderMatcher' interface='false' size='17'></ClassStats>
+      <ClassStats sourceFile='IsListEmptyMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsListEmptyMatcher' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='IsMapEmptyMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsMapEmptyMatcher' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='IsMemberPackageProtectedMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsMemberPackageProtectedMatcher' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='IsMemberPublicMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsMemberPublicMatcher' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='IsOfLengthMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsOfLengthMatcher' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='IsTransactionalMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsTransactionalMatcher' interface='false' size='30'></ClassStats>
+      <ClassStats sourceFile='IsUrlMatcher.java' bugs='0' class='somepackage.test.hamcrest.IsUrlMatcher' interface='false' size='23'></ClassStats>
+      <ClassStats sourceFile='MapContainsEntriesMatcher.java' bugs='0' class='somepackage.test.hamcrest.MapContainsEntriesMatcher' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='MatchesRegexMatcher.java' bugs='0' class='somepackage.test.hamcrest.MatchesRegexMatcher' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='somepackage.test.hamcrest.ReflectionMatchers' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='somepackage.test.hamcrest.StringMatchers' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='TransactionalMatchers.java' bugs='0' class='somepackage.test.hamcrest.TransactionalMatchers' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='UrlMatchers.java' bugs='0' class='somepackage.test.hamcrest.UrlMatchers' interface='false' size='6'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='27' package='com.aconex.test.mockito' total_bugs='0' total_types='4'>
-      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='com.aconex.test.mockito.ReflectionMatchers' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='com.aconex.test.mockito.ReflectionMatchers$1' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='com.aconex.test.mockito.StringMatchers' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='com.aconex.test.mockito.StringMatchers$1' interface='false' size='5'></ClassStats>
+    <PackageStats total_size='27' package='somepackage.test.mockito' total_bugs='0' total_types='4'>
+      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='somepackage.test.mockito.ReflectionMatchers' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='somepackage.test.mockito.ReflectionMatchers$1' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='somepackage.test.mockito.StringMatchers' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='somepackage.test.mockito.StringMatchers$1' interface='false' size='5'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='1' priority_1='3' total_size='903' package='com.aconex.utilities' total_bugs='6' priority_3='2' total_types='28'>
-      <ClassStats sourceFile='AnnotationEqualityHelper.java' bugs='0' class='com.aconex.utilities.AnnotationEqualityHelper' interface='false' size='111'></ClassStats>
-      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='com.aconex.utilities.ArgumentValidator' interface='false' size='34'></ClassStats>
-      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='com.aconex.utilities.ArgumentValidator$1' interface='false' size='7'></ClassStats>
-      <ClassStats priority_1='1' sourceFile='BeanUtils.java' bugs='1' class='com.aconex.utilities.BeanUtils' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='ConfigConstants.java' bugs='0' class='com.aconex.utilities.ConfigConstants' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='CryptographyException.java' bugs='0' class='com.aconex.utilities.CryptographyException' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='DataManipulation.java' bugs='0' class='com.aconex.utilities.DataManipulation' interface='false' size='92'></ClassStats>
-      <ClassStats sourceFile='EnumUtils.java' bugs='0' class='com.aconex.utilities.EnumUtils' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='EqualityField.java' bugs='0' class='com.aconex.utilities.EqualityField' interface='true' size='1'></ClassStats>
-      <ClassStats sourceFile='FormUtils.java' bugs='0' class='com.aconex.utilities.FormUtils' interface='false' size='16'></ClassStats>
-      <ClassStats sourceFile='GuidGenerator.java' bugs='0' class='com.aconex.utilities.GuidGenerator' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat' interface='false' size='38'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat$1' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat$2' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat$3' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HTMLFormatRules.java' bugs='0' class='com.aconex.utilities.HTMLFormatRules' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='JMXUtils.java' bugs='0' class='com.aconex.utilities.JMXUtils' interface='false' size='25'></ClassStats>
-      <ClassStats priority_1='1' sourceFile='NumberUtils.java' bugs='1' class='com.aconex.utilities.NumberUtils' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='SHA1.java' bugs='0' class='com.aconex.utilities.SHA1' interface='false' size='199'></ClassStats>
-      <ClassStats priority_1='1' sourceFile='StringEscapeUtils.java' bugs='1' class='com.aconex.utilities.StringEscapeUtils' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='StringTrimingUtils.java' bugs='0' class='com.aconex.utilities.StringTrimingUtils' interface='false' size='20'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='TimingStatistics.java' bugs='1' class='com.aconex.utilities.TimingStatistics' interface='false' size='49'></ClassStats>
-      <ClassStats sourceFile='TransientHolder.java' bugs='0' class='com.aconex.utilities.TransientHolder' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='URLUtils.java' bugs='1' class='com.aconex.utilities.URLUtils' interface='false' priority_3='1' size='137'></ClassStats>
-      <ClassStats sourceFile='ValidationUtils.java' bugs='0' class='com.aconex.utilities.ValidationUtils' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='XMLUtils.java' bugs='1' class='com.aconex.utilities.XMLUtils' interface='false' priority_3='1' size='26'></ClassStats>
-      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='com.aconex.utilities.XStreamUtils' interface='false' size='19'></ClassStats>
-      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='com.aconex.utilities.XStreamUtils$1' interface='false' size='5'></ClassStats>
+    <PackageStats priority_2='1' priority_1='3' total_size='903' package='somepackage.utilities' total_bugs='6' priority_3='2' total_types='28'>
+      <ClassStats sourceFile='AnnotationEqualityHelper.java' bugs='0' class='somepackage.utilities.AnnotationEqualityHelper' interface='false' size='111'></ClassStats>
+      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='somepackage.utilities.ArgumentValidator' interface='false' size='34'></ClassStats>
+      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='somepackage.utilities.ArgumentValidator$1' interface='false' size='7'></ClassStats>
+      <ClassStats priority_1='1' sourceFile='BeanUtils.java' bugs='1' class='somepackage.utilities.BeanUtils' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='ConfigConstants.java' bugs='0' class='somepackage.utilities.ConfigConstants' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='CryptographyException.java' bugs='0' class='somepackage.utilities.CryptographyException' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='DataManipulation.java' bugs='0' class='somepackage.utilities.DataManipulation' interface='false' size='92'></ClassStats>
+      <ClassStats sourceFile='EnumUtils.java' bugs='0' class='somepackage.utilities.EnumUtils' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='EqualityField.java' bugs='0' class='somepackage.utilities.EqualityField' interface='true' size='1'></ClassStats>
+      <ClassStats sourceFile='FormUtils.java' bugs='0' class='somepackage.utilities.FormUtils' interface='false' size='16'></ClassStats>
+      <ClassStats sourceFile='GuidGenerator.java' bugs='0' class='somepackage.utilities.GuidGenerator' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepackage.utilities.HTMLFormat' interface='false' size='38'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepackage.utilities.HTMLFormat$1' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepackage.utilities.HTMLFormat$2' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepackage.utilities.HTMLFormat$3' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HTMLFormatRules.java' bugs='0' class='somepackage.utilities.HTMLFormatRules' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='JMXUtils.java' bugs='0' class='somepackage.utilities.JMXUtils' interface='false' size='25'></ClassStats>
+      <ClassStats priority_1='1' sourceFile='NumberUtils.java' bugs='1' class='somepackage.utilities.NumberUtils' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='SHA1.java' bugs='0' class='somepackage.utilities.SHA1' interface='false' size='199'></ClassStats>
+      <ClassStats priority_1='1' sourceFile='StringEscapeUtils.java' bugs='1' class='somepackage.utilities.StringEscapeUtils' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='StringTrimingUtils.java' bugs='0' class='somepackage.utilities.StringTrimingUtils' interface='false' size='20'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='TimingStatistics.java' bugs='1' class='somepackage.utilities.TimingStatistics' interface='false' size='49'></ClassStats>
+      <ClassStats sourceFile='TransientHolder.java' bugs='0' class='somepackage.utilities.TransientHolder' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='URLUtils.java' bugs='1' class='somepackage.utilities.URLUtils' interface='false' priority_3='1' size='137'></ClassStats>
+      <ClassStats sourceFile='ValidationUtils.java' bugs='0' class='somepackage.utilities.ValidationUtils' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='XMLUtils.java' bugs='1' class='somepackage.utilities.XMLUtils' interface='false' priority_3='1' size='26'></ClassStats>
+      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='somepackage.utilities.XStreamUtils' interface='false' size='19'></ClassStats>
+      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='somepackage.utilities.XStreamUtils$1' interface='false' size='5'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='235' package='com.aconex.utilities.browser' total_bugs='11' priority_3='11' total_types='2'>
-      <ClassStats sourceFile='BrowserProperties.java' bugs='3' class='com.aconex.utilities.browser.BrowserProperties' interface='false' priority_3='3' size='120'></ClassStats>
-      <ClassStats sourceFile='BrowserSniffer.java' bugs='8' class='com.aconex.utilities.browser.BrowserSniffer' interface='false' priority_3='8' size='115'></ClassStats>
+    <PackageStats total_size='235' package='somepackage.utilities.browser' total_bugs='11' priority_3='11' total_types='2'>
+      <ClassStats sourceFile='BrowserProperties.java' bugs='3' class='somepackage.utilities.browser.BrowserProperties' interface='false' priority_3='3' size='120'></ClassStats>
+      <ClassStats sourceFile='BrowserSniffer.java' bugs='8' class='somepackage.utilities.browser.BrowserSniffer' interface='false' priority_3='8' size='115'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='3' total_size='651' package='com.aconex.utilities.db' total_bugs='7' priority_3='4' total_types='17'>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource' interface='true' size='7'></ClassStats>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource$1' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource$2' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource$2$1' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver' interface='false' size='103'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$1' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' interface='false' priority_3='1' size='76'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' interface='false' size='25'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' interface='false' size='39'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' interface='false' size='162'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$1' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='3' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' interface='false' priority_3='3' size='103'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$CpuWarningFilter' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$IoWarningFilter' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$WarningFilter' interface='false' size='16'></ClassStats>
-      <ClassStats sourceFile='MDCLoggerDataSource.java' bugs='0' class='com.aconex.utilities.db.MDCLoggerDataSource' interface='false' size='41'></ClassStats>
-      <ClassStats sourceFile='SQLServerUtils.java' bugs='0' class='com.aconex.utilities.db.SQLServerUtils' interface='false' size='21'></ClassStats>
+    <PackageStats priority_2='3' total_size='651' package='somepackage.utilities.db' total_bugs='7' priority_3='4' total_types='17'>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepackage.utilities.db.ConnectionIdSource' interface='true' size='7'></ClassStats>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepackage.utilities.db.ConnectionIdSource$1' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepackage.utilities.db.ConnectionIdSource$2' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepackage.utilities.db.ConnectionIdSource$2$1' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepackage.utilities.db.LoggingDriver' interface='false' size='103'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepackage.utilities.db.LoggingDriver$1' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='1' class='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler' interface='false' priority_3='1' size='76'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' interface='false' size='25'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='somepackage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' interface='false' size='39'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor' interface='false' size='162'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$1' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='3' class='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' interface='false' priority_3='3' size='103'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$CpuWarningFilter' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$IoWarningFilter' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepackage.utilities.db.LoggingDriver$LoggingDriverMonitor$WarningFilter' interface='false' size='16'></ClassStats>
+      <ClassStats sourceFile='MDCLoggerDataSource.java' bugs='0' class='somepackage.utilities.db.MDCLoggerDataSource' interface='false' size='41'></ClassStats>
+      <ClassStats sourceFile='SQLServerUtils.java' bugs='0' class='somepackage.utilities.db.SQLServerUtils' interface='false' size='21'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='24' package='com.aconex.utilities.decorators' total_bugs='0' total_types='4'>
-      <ClassStats sourceFile='AbstractDecorator.java' bugs='0' class='com.aconex.utilities.decorators.AbstractDecorator' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='AbstractRunnableDecorator.java' bugs='0' class='com.aconex.utilities.decorators.AbstractRunnableDecorator' interface='false' size='4'></ClassStats>
-      <ClassStats sourceFile='Decorator.java' bugs='0' class='com.aconex.utilities.decorators.Decorator' interface='true' size='2'></ClassStats>
-      <ClassStats sourceFile='Decorator.java' bugs='0' class='com.aconex.utilities.decorators.Decorator$Helper' interface='false' size='10'></ClassStats>
+    <PackageStats total_size='24' package='somepackage.utilities.decorators' total_bugs='0' total_types='4'>
+      <ClassStats sourceFile='AbstractDecorator.java' bugs='0' class='somepackage.utilities.decorators.AbstractDecorator' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='AbstractRunnableDecorator.java' bugs='0' class='somepackage.utilities.decorators.AbstractRunnableDecorator' interface='false' size='4'></ClassStats>
+      <ClassStats sourceFile='Decorator.java' bugs='0' class='somepackage.utilities.decorators.Decorator' interface='true' size='2'></ClassStats>
+      <ClassStats sourceFile='Decorator.java' bugs='0' class='somepackage.utilities.decorators.Decorator$Helper' interface='false' size='10'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='21' package='com.aconex.utilities.encoder' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='DigestUtils.java' bugs='0' class='com.aconex.utilities.encoder.DigestUtils' interface='false' size='21'></ClassStats>
+    <PackageStats total_size='21' package='somepackage.utilities.encoder' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='DigestUtils.java' bugs='0' class='somepackage.utilities.encoder.DigestUtils' interface='false' size='21'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='1' total_size='118' package='com.aconex.utilities.message' total_bugs='1' total_types='5'>
-      <ClassStats priority_2='1' sourceFile='Message.java' bugs='1' class='com.aconex.utilities.message.Message' interface='false' size='35'></ClassStats>
-      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='com.aconex.utilities.message.MessageContainer' interface='false' size='44'></ClassStats>
-      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='com.aconex.utilities.message.MessageContainer$1' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='com.aconex.utilities.message.MessageContainer$2' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='MessageType.java' bugs='0' class='com.aconex.utilities.message.MessageType' interface='false' size='23'></ClassStats>
+    <PackageStats priority_2='1' total_size='118' package='somepackage.utilities.message' total_bugs='1' total_types='5'>
+      <ClassStats priority_2='1' sourceFile='Message.java' bugs='1' class='somepackage.utilities.message.Message' interface='false' size='35'></ClassStats>
+      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='somepackage.utilities.message.MessageContainer' interface='false' size='44'></ClassStats>
+      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='somepackage.utilities.message.MessageContainer$1' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='somepackage.utilities.message.MessageContainer$2' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='MessageType.java' bugs='0' class='somepackage.utilities.message.MessageType' interface='false' size='23'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='67' package='com.aconex.utilities.tuples' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='Pair.java' bugs='0' class='com.aconex.utilities.tuples.Pair' interface='false' size='67'></ClassStats>
+    <PackageStats total_size='67' package='somepackage.utilities.tuples' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='Pair.java' bugs='0' class='somepackage.utilities.tuples.Pair' interface='false' size='67'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='22' package='com.aconex.utilities.web.binding.editors' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='AbstractPropertyEditor.java' bugs='0' class='com.aconex.utilities.web.binding.editors.AbstractPropertyEditor' interface='false' size='22'></ClassStats>
+    <PackageStats total_size='22' package='somepackage.utilities.web.binding.editors' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='AbstractPropertyEditor.java' bugs='0' class='somepackage.utilities.web.binding.editors.AbstractPropertyEditor' interface='false' size='22'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='36' package='com.aconex.velocity' total_bugs='3' priority_3='3' total_types='1'>
-      <ClassStats sourceFile='VelocityUtils.java' bugs='3' class='com.aconex.velocity.VelocityUtils' interface='false' priority_3='3' size='36'></ClassStats>
+    <PackageStats total_size='36' package='somepackage.velocity' total_bugs='3' priority_3='3' total_types='1'>
+      <ClassStats sourceFile='VelocityUtils.java' bugs='3' class='somepackage.velocity.VelocityUtils' interface='false' priority_3='3' size='36'></ClassStats>
     </PackageStats>
     <FindBugsProfile>
       <ClassProfile avgMicrosecondsPerInvocation='84' maxMicrosecondsPerInvocation='868' name='edu.umd.cs.findbugs.detect.NumberConstructor' invocations='135' totalMilliseconds='11' standardDeviationMircosecondsPerInvocation='126'></ClassProfile>

--- a/dybdob-detectors/src/test/resources/findbugsXmlNoHighPriority.xml
+++ b/dybdob-detectors/src/test/resources/findbugsXmlNoHighPriority.xml
@@ -1,412 +1,213 @@
 <BugCollection timestamp='1282545580000' analysisTimestamp='1282545593845' sequence='0' release='' version='1.3.9'>
   <Project projectName=''>
-    <Jar>/home/ykulbak/dev/babylon-git/utilities/aconex-utils/target/classes</Jar>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/apache/maven/reporting/maven-reporting-impl/2.0/maven-reporting-impl-2.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/codehaus/plexus/plexus-utils/1.5.1/plexus-utils-1.5.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-validator/commons-validator/1.1.4/commons-validator-1.1.4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/oro/oro/2.0.7/oro-2.0.7.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/doxia/doxia-core/1.0-alpha-4/doxia-core-1.0-alpha-4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/apache/maven/shared/maven-doxia-tools/1.0/maven-doxia-tools-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-io/commons-io/1.4/commons-io-1.4.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/apache/maven/doxia/doxia-decoration-model/1.0-alpha-11/doxia-decoration-model-1.0-alpha-11.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/plexus/plexus-i18n/1.0-beta-7/plexus-i18n-1.0-beta-7.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/findbugs-ant/1.3.9/findbugs-ant-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/findbugs/1.3.9/findbugs-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/bcel/1.3.9/bcel-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/jsr305/1.3.9/jsr305-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/jFormatString/1.3.9/jFormatString-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/code/findbugs/annotations/1.3.9/annotations-1.3.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/dom4j/dom4j/1.6.1/dom4j-1.6.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xml-apis/xml-apis/1.0.b2/xml-apis-1.0.b2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jaxen/jaxen/1.1.1/jaxen-1.1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jdom/jdom/1.0/jdom-1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xerces/xercesImpl/2.6.2/xercesImpl-2.6.2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xom/xom/1.0/xom-1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xerces/xmlParserAPIs/2.6.2/xmlParserAPIs-2.6.2.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xalan/xalan/2.6.0/xalan-2.6.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/ibm/icu/icu4j/2.6.1/icu4j-2.6.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm/3.1/asm-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-analysis/3.1/asm-analysis-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-tree/3.1/asm-tree-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-commons/3.1/asm-commons-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-util/3.1/asm-util-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/asm/asm-xml/3.1/asm-xml-3.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-lang/commons-lang/2.4/commons-lang-2.4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jgoodies/plastic/1.2.0/plastic-1.2.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/gmaven-mojo/1.0-rc-3/gmaven-mojo-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-api/1.0-rc-3/gmaven-runtime-api-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/feature/gmaven-feature-api/1.0-rc-3/gmaven-feature-api-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-default/1.0-rc-3/gmaven-runtime-default-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/slf4j/slf4j-api/1.5.0/slf4j-api-1.5.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-1.5/1.0-rc-3/gmaven-runtime-1.5-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/feature/gmaven-feature-support/1.0-rc-3/gmaven-feature-support-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/runtime/gmaven-runtime-support/1.0-rc-3/gmaven-runtime-support-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/maven/gmaven-common/1.0-rc-3/gmaven-common-1.0-rc-3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/thoughtworks/qdox/qdox/1.6.3/qdox-1.6.3.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/groovy/groovy-all-minimal/1.5.6/groovy-all-minimal-1.5.6.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant/1.7.1/ant-1.7.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant-launcher/1.7.1/ant-launcher-1.7.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/jline/jline/0.9.94/jline-0.9.94.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/codehaus/plexus/plexus-resources/1.0-alpha-4/plexus-resources-1.0-alpha-4.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/dev/java/apache-maven-2.2.1/lib/maven-2.2.1-uber.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/aconex/utils/aconex-intelligent-test/1.0.0/aconex-intelligent-test-1.0.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/junit/junit/3.8.1/junit-3.8.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/mail/mail/1.4/mail-1.4.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/activation/activation/1.1/activation-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/springframework/spring/2.5.6/spring-2.5.6.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-logging/commons-logging/1.1.1/commons-logging-1.1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/servlet/servlet-api/2.5/servlet-api-2.5.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-beanutils/commons-beanutils/1.7.0/commons-beanutils-1.7.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/hibernate/hibernate-core/3.3.1.GA/hibernate-core-3.3.1.GA.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/antlr/antlr/2.7.6/antlr-2.7.6.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-collections/commons-collections/3.2.1/commons-collections-3.2.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/transaction/jta/1.1/jta-1.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-codec/commons-codec/1.3/commons-codec-1.3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/log4j/log4j/1.2.14/log4j-1.2.14.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant/1.7.0/ant-1.7.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/ant/ant-launcher/1.7.0/ant-launcher-1.7.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-dbutils/commons-dbutils/1.1/commons-dbutils-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/thoughtworks/xstream/xstream/1.3.1/xstream-1.3.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xpp3/xpp3_min/1.1.3.4.O/xpp3_min-1.1.3.4.O.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/velocity/velocity/1.5/velocity-1.5.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/oro/oro/2.0.8/oro-2.0.8.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-math/commons-math/1.2/commons-math-1.2.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/apache/velocity/velocity-tools/1.3/velocity-tools-1.3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-digester/commons-digester/1.8/commons-digester-1.8.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/commons-validator/commons-validator/1.3.1/commons-validator-1.3.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/sslext/sslext/1.2-0/sslext-1.2-0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/struts/struts/1.2.9/struts-1.2.9.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/commons-fileupload/commons-fileupload/1.0/commons-fileupload-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/xalan/xalan/2.5.1/xalan-2.5.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/velocity/velocity/1.4/velocity-1.4.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/hibernate/hibernate-annotations/3.4.0.GA/hibernate-annotations-3.4.0.GA.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/org/hibernate/hibernate-commons-annotations/3.3.0.ga/hibernate-commons-annotations-3.3.0.ga.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-spring-utils/1.9/aconex-spring-utils-1.9.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/net/jcip/jcip-annotations/1.0/jcip-annotations-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/persistence/persistence-api/1.0/persistence-api-1.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/utils/aconex-utils-lang/1.0.8/aconex-utils-lang-1.0.8.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/joda-time/joda-time/1.2.1.20071016/joda-time-1.2.1.20071016.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/aconex/utils/aconex-utils-collections/1.0.14/aconex-utils-collections-1.0.14.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-assert/1.3/aconex-assert-1.3.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/aconex/aconex-applicationexception/1.1/aconex-applicationexception-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/google/guava/guava/r05/guava-r05.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/utils/aconex-utils-db/1.2/aconex-utils-db-1.2.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/hamcrest/hamcrest-all/1.1/hamcrest-all-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/mockito/mockito-core/1.8.0/mockito-core-1.8.0.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/hamcrest/hamcrest-core/1.1/hamcrest-core-1.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/objenesis/objenesis/1.0/objenesis-1.0.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/hsqldb/hsqldb/1.8.0.7/hsqldb-1.8.0.7.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/c3p0/c3p0/0.9.1.2/c3p0-0.9.1.2.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-jtds/1.2.1.7/aconex-jtds-1.2.1.7.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/samba/jcifs/jcifs/1.2.15/jcifs-1.2.15.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/custardsource/parfait/parfait-core/0.2.2-SNAPSHOT/parfait-core-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/javax/measure/jsr-275/0.9.1/jsr-275-0.9.1.jar</AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/custardsource/parfait/parfait-pcp/0.2.2-SNAPSHOT/parfait-pcp-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/custardsource/parfait/dxm/0.2.2-SNAPSHOT/dxm-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>
-      /home/ykulbak/.m2/repository/com/custardsource/parfait/parfait-spring/0.2.2-SNAPSHOT/parfait-spring-0.2.2-SNAPSHOT.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/org/aspectj/aspectjweaver/1.6.1/aspectjweaver-1.6.1.jar
-    </AuxClasspathEntry>
-    <AuxClasspathEntry>/home/ykulbak/.m2/repository/com/aconex/aconex-i18n-utils/1.0.10/aconex-i18n-utils-1.0.10.jar
-    </AuxClasspathEntry>
-    <SrcDir>/home/ykulbak/dev/babylon-git/utilities/aconex-utils/src/main/java</SrcDir>
-    <WrkDir>/home/ykulbak/dev/babylon-git/utilities/aconex-utils/target</WrkDir>
   </Project>
   <BugInstance category='CORRECTNESS' instanceHash='700a71ba286b5cae4962b2f59b772eb5' instanceOccurrenceNum='0' priority='2' abbrev='UwF' type='UWF_UNWRITTEN_FIELD' instanceOccurrenceMax='0'>
     <ShortMessage>Unwritten field</ShortMessage>
-    <LongMessage>Unwritten field: com.aconex.db.JdbcSettingsMBean.instance</LongMessage>
-    <Class classname='com.aconex.db.JdbcSettingsMBean' primary='true'>
-      <SourceLine start='7' classname='com.aconex.db.JdbcSettingsMBean' sourcepath='com/aconex/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='37'>
+    <LongMessage>Unwritten field: somepakage.db.JdbcSettingsMBean.instance</LongMessage>
+    <Class classname='somepakage.db.JdbcSettingsMBean' primary='true'>
+      <SourceLine start='7' classname='somepakage.db.JdbcSettingsMBean' sourcepath='somepakage/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='37'>
         <Message>At JdbcSettingsMBean.java:[lines 7-37]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.JdbcSettingsMBean</Message>
+      <Message>In class somepakage.db.JdbcSettingsMBean</Message>
     </Class>
-    <Field isStatic='true' classname='com.aconex.db.JdbcSettingsMBean' name='instance' primary='true' signature='Lcom/aconex/db/JdbcSettingsMBean;'>
-      <SourceLine classname='com.aconex.db.JdbcSettingsMBean' sourcepath='com/aconex/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java'>
+    <Field isStatic='true' classname='somepakage.db.JdbcSettingsMBean' name='instance' primary='true' signature='Lsomepakage/db/JdbcSettingsMBean;'>
+      <SourceLine classname='somepakage.db.JdbcSettingsMBean' sourcepath='somepakage/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java'>
         <Message>In JdbcSettingsMBean.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.JdbcSettingsMBean.instance</Message>
+      <Message>Field somepakage.db.JdbcSettingsMBean.instance</Message>
     </Field>
-    <SourceLine endBytecode='0' startBytecode='0' start='12' classname='com.aconex.db.JdbcSettingsMBean' primary='true' sourcepath='com/aconex/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='12'>
+    <SourceLine endBytecode='0' startBytecode='0' start='12' classname='somepakage.db.JdbcSettingsMBean' primary='true' sourcepath='somepakage/db/JdbcSettingsMBean.java' sourcefile='JdbcSettingsMBean.java' end='12'>
       <Message>At JdbcSettingsMBean.java:[line 12]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='6dd87f6a319d350d0484b038ec9b6d08' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
     <LongMessage>Exception is caught when Exception is not thrown in
-      com.aconex.db.LegacyService.installAsStaticInstance()
+      somepakage.db.LegacyService.installAsStaticInstance()
     </LongMessage>
-    <Class classname='com.aconex.db.LegacyService' primary='true'>
-      <SourceLine start='31' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
+    <Class classname='somepakage.db.LegacyService' primary='true'>
+      <SourceLine start='31' classname='somepakage.db.LegacyService' sourcepath='somepakage/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
         <Message>At LegacyService.java:[lines 31-133]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.LegacyService</Message>
+      <Message>In class somepakage.db.LegacyService</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.LegacyService' name='installAsStaticInstance' primary='true' signature='()V'>
-      <SourceLine endBytecode='169' startBytecode='0' start='109' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='116'></SourceLine>
-      <Message>In method com.aconex.db.LegacyService.installAsStaticInstance()</Message>
+    <Method isStatic='false' classname='somepakage.db.LegacyService' name='installAsStaticInstance' primary='true' signature='()V'>
+      <SourceLine endBytecode='169' startBytecode='0' start='109' classname='somepakage.db.LegacyService' sourcepath='somepakage/db/LegacyService.java' sourcefile='LegacyService.java' end='116'></SourceLine>
+      <Message>In method somepakage.db.LegacyService.installAsStaticInstance()</Message>
     </Method>
-    <SourceLine endBytecode='52' startBytecode='52' start='113' classname='com.aconex.db.LegacyService' primary='true' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='113'>
+    <SourceLine endBytecode='52' startBytecode='52' start='113' classname='somepakage.db.LegacyService' primary='true' sourcepath='somepakage/db/LegacyService.java' sourcefile='LegacyService.java' end='113'>
       <Message>At LegacyService.java:[line 113]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='4d23aeaaf1a8a49ff660ee05e4542b9' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
     <LongMessage>Exception is caught when Exception is not thrown in
-      com.aconex.db.LegacyService.uninstallAsStaticInstance()
+      somepakage.db.LegacyService.uninstallAsStaticInstance()
     </LongMessage>
-    <Class classname='com.aconex.db.LegacyService' primary='true'>
-      <SourceLine start='31' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
+    <Class classname='somepakage.db.LegacyService' primary='true'>
+      <SourceLine start='31' classname='somepakage.db.LegacyService' sourcepath='somepakage/db/LegacyService.java' sourcefile='LegacyService.java' end='133'>
         <Message>At LegacyService.java:[lines 31-133]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.LegacyService</Message>
+      <Message>In class somepakage.db.LegacyService</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.LegacyService' name='uninstallAsStaticInstance' primary='true' signature='()V'>
-      <SourceLine endBytecode='195' startBytecode='0' start='120' classname='com.aconex.db.LegacyService' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='128'></SourceLine>
-      <Message>In method com.aconex.db.LegacyService.uninstallAsStaticInstance()</Message>
+    <Method isStatic='false' classname='somepakage.db.LegacyService' name='uninstallAsStaticInstance' primary='true' signature='()V'>
+      <SourceLine endBytecode='195' startBytecode='0' start='120' classname='somepakage.db.LegacyService' sourcepath='somepakage/db/LegacyService.java' sourcefile='LegacyService.java' end='128'></SourceLine>
+      <Message>In method somepakage.db.LegacyService.uninstallAsStaticInstance()</Message>
     </Method>
-    <SourceLine endBytecode='61' startBytecode='61' start='125' classname='com.aconex.db.LegacyService' primary='true' sourcepath='com/aconex/db/LegacyService.java' sourcefile='LegacyService.java' end='125'>
+    <SourceLine endBytecode='61' startBytecode='61' start='125' classname='somepakage.db.LegacyService' primary='true' sourcepath='somepakage/db/LegacyService.java' sourcefile='LegacyService.java' end='125'>
       <Message>At LegacyService.java:[line 125]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='d4eafdd8d320bab2e1e0af42e567af45' instanceOccurrenceNum='0' priority='2' abbrev='EI2' type='EI_EXPOSE_REP2' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>new com.aconex.db.hibernate.BaseInExpression(Object[], Criterion) may expose internal representation by
+    <LongMessage>new somepakage.db.hibernate.BaseInExpression(Object[], Criterion) may expose internal representation by
       storing an externally mutable object into BaseInExpression.values
     </LongMessage>
-    <Class classname='com.aconex.db.hibernate.BaseInExpression' primary='true'>
-      <SourceLine start='30' classname='com.aconex.db.hibernate.BaseInExpression' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='99'>
+    <Class classname='somepakage.db.hibernate.BaseInExpression' primary='true'>
+      <SourceLine start='30' classname='somepakage.db.hibernate.BaseInExpression' sourcepath='somepakage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='99'>
         <Message>At BaseInExpression.java:[lines 30-99]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.hibernate.BaseInExpression</Message>
+      <Message>In class somepakage.db.hibernate.BaseInExpression</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.hibernate.BaseInExpression' name='&lt;init&gt;' primary='true' signature='([Ljava/lang/Object;Lorg/hibernate/criterion/Criterion;)V'>
-      <SourceLine endBytecode='88' startBytecode='0' start='30' classname='com.aconex.db.hibernate.BaseInExpression' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='33'></SourceLine>
-      <Message>In method new com.aconex.db.hibernate.BaseInExpression(Object[], Criterion)</Message>
+    <Method isStatic='false' classname='somepakage.db.hibernate.BaseInExpression' name='&lt;init&gt;' primary='true' signature='([Ljava/lang/Object;Lorg/hibernate/criterion/Criterion;)V'>
+      <SourceLine endBytecode='88' startBytecode='0' start='30' classname='somepakage.db.hibernate.BaseInExpression' sourcepath='somepakage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='33'></SourceLine>
+      <Message>In method new somepakage.db.hibernate.BaseInExpression(Object[], Criterion)</Message>
     </Method>
-    <Field isStatic='false' classname='com.aconex.db.hibernate.BaseInExpression' name='values' primary='true' signature='[Ljava/lang/Object;'>
-      <SourceLine classname='com.aconex.db.hibernate.BaseInExpression' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java'>
+    <Field isStatic='false' classname='somepakage.db.hibernate.BaseInExpression' name='values' primary='true' signature='[Ljava/lang/Object;'>
+      <SourceLine classname='somepakage.db.hibernate.BaseInExpression' sourcepath='somepakage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java'>
         <Message>In BaseInExpression.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.hibernate.BaseInExpression.values</Message>
+      <Message>Field somepakage.db.hibernate.BaseInExpression.values</Message>
     </Field>
     <LocalVariable register='1' name='values' pc='6' role='LOCAL_VARIABLE_NAMED'>
       <Message>Local variable named values</Message>
     </LocalVariable>
-    <SourceLine endBytecode='6' startBytecode='6' start='31' classname='com.aconex.db.hibernate.BaseInExpression' primary='true' sourcepath='com/aconex/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='31'>
+    <SourceLine endBytecode='6' startBytecode='6' start='31' classname='somepakage.db.hibernate.BaseInExpression' primary='true' sourcepath='somepakage/db/hibernate/BaseInExpression.java' sourcefile='BaseInExpression.java' end='31'>
       <Message>At BaseInExpression.java:[line 31]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='8c159f580ea7284066808f78a827105e' instanceOccurrenceNum='0' priority='2' abbrev='EI' type='EI_EXPOSE_REP' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.aconex.db.usertypes.KeyedEnumUserType.sqlTypes() may expose internal representation by returning
+    <LongMessage>somepakage.db.usertypes.KeyedEnumUserType.sqlTypes() may expose internal representation by returning
       KeyedEnumUserType.RETURN_TYPE
     </LongMessage>
-    <Class classname='com.aconex.db.usertypes.KeyedEnumUserType' primary='true'>
-      <SourceLine start='37' classname='com.aconex.db.usertypes.KeyedEnumUserType' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='150'>
+    <Class classname='somepakage.db.usertypes.KeyedEnumUserType' primary='true'>
+      <SourceLine start='37' classname='somepakage.db.usertypes.KeyedEnumUserType' sourcepath='somepakage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='150'>
         <Message>At KeyedEnumUserType.java:[lines 37-150]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.usertypes.KeyedEnumUserType</Message>
+      <Message>In class somepakage.db.usertypes.KeyedEnumUserType</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.usertypes.KeyedEnumUserType' name='sqlTypes' primary='true' signature='()[I'>
-      <SourceLine endBytecode='45' startBytecode='0' start='93' classname='com.aconex.db.usertypes.KeyedEnumUserType' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'></SourceLine>
-      <Message>In method com.aconex.db.usertypes.KeyedEnumUserType.sqlTypes()</Message>
+    <Method isStatic='false' classname='somepakage.db.usertypes.KeyedEnumUserType' name='sqlTypes' primary='true' signature='()[I'>
+      <SourceLine endBytecode='45' startBytecode='0' start='93' classname='somepakage.db.usertypes.KeyedEnumUserType' sourcepath='somepakage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'></SourceLine>
+      <Message>In method somepakage.db.usertypes.KeyedEnumUserType.sqlTypes()</Message>
     </Method>
-    <Field isStatic='true' classname='com.aconex.db.usertypes.KeyedEnumUserType' name='RETURN_TYPE' primary='true' signature='[I'>
-      <SourceLine classname='com.aconex.db.usertypes.KeyedEnumUserType' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java'>
+    <Field isStatic='true' classname='somepakage.db.usertypes.KeyedEnumUserType' name='RETURN_TYPE' primary='true' signature='[I'>
+      <SourceLine classname='somepakage.db.usertypes.KeyedEnumUserType' sourcepath='somepakage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java'>
         <Message>In KeyedEnumUserType.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.usertypes.KeyedEnumUserType.RETURN_TYPE</Message>
+      <Message>Field somepakage.db.usertypes.KeyedEnumUserType.RETURN_TYPE</Message>
     </Field>
-    <SourceLine endBytecode='3' startBytecode='3' start='93' classname='com.aconex.db.usertypes.KeyedEnumUserType' primary='true' sourcepath='com/aconex/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'>
+    <SourceLine endBytecode='3' startBytecode='3' start='93' classname='somepakage.db.usertypes.KeyedEnumUserType' primary='true' sourcepath='somepakage/db/usertypes/KeyedEnumUserType.java' sourcefile='KeyedEnumUserType.java' end='93'>
       <Message>At KeyedEnumUserType.java:[line 93]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='6cbe066798c4abb901a3d6e15aa0ec6b' instanceOccurrenceNum='0' priority='2' abbrev='EI' type='EI_EXPOSE_REP' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by returning reference to mutable object</ShortMessage>
-    <LongMessage>com.aconex.db.usertypes.XStreamUserType.sqlTypes() may expose internal representation by returning
+    <LongMessage>somepakage.db.usertypes.XStreamUserType.sqlTypes() may expose internal representation by returning
       XStreamUserType.SQL_TYPES
     </LongMessage>
-    <Class classname='com.aconex.db.usertypes.XStreamUserType' primary='true'>
-      <SourceLine start='27' classname='com.aconex.db.usertypes.XStreamUserType' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='86'>
+    <Class classname='somepakage.db.usertypes.XStreamUserType' primary='true'>
+      <SourceLine start='27' classname='somepakage.db.usertypes.XStreamUserType' sourcepath='somepakage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='86'>
         <Message>At XStreamUserType.java:[lines 27-86]</Message>
       </SourceLine>
-      <Message>In class com.aconex.db.usertypes.XStreamUserType</Message>
+      <Message>In class somepakage.db.usertypes.XStreamUserType</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.db.usertypes.XStreamUserType' name='sqlTypes' primary='true' signature='()[I'>
-      <SourceLine endBytecode='45' startBytecode='0' start='76' classname='com.aconex.db.usertypes.XStreamUserType' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'></SourceLine>
-      <Message>In method com.aconex.db.usertypes.XStreamUserType.sqlTypes()</Message>
+    <Method isStatic='false' classname='somepakage.db.usertypes.XStreamUserType' name='sqlTypes' primary='true' signature='()[I'>
+      <SourceLine endBytecode='45' startBytecode='0' start='76' classname='somepakage.db.usertypes.XStreamUserType' sourcepath='somepakage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'></SourceLine>
+      <Message>In method somepakage.db.usertypes.XStreamUserType.sqlTypes()</Message>
     </Method>
-    <Field isStatic='true' classname='com.aconex.db.usertypes.XStreamUserType' name='SQL_TYPES' primary='true' signature='[I'>
-      <SourceLine classname='com.aconex.db.usertypes.XStreamUserType' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java'>
+    <Field isStatic='true' classname='somepakage.db.usertypes.XStreamUserType' name='SQL_TYPES' primary='true' signature='[I'>
+      <SourceLine classname='somepakage.db.usertypes.XStreamUserType' sourcepath='somepakage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java'>
         <Message>In XStreamUserType.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.db.usertypes.XStreamUserType.SQL_TYPES</Message>
+      <Message>Field somepakage.db.usertypes.XStreamUserType.SQL_TYPES</Message>
     </Field>
-    <SourceLine endBytecode='3' startBytecode='3' start='76' classname='com.aconex.db.usertypes.XStreamUserType' primary='true' sourcepath='com/aconex/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'>
+    <SourceLine endBytecode='3' startBytecode='3' start='76' classname='somepakage.db.usertypes.XStreamUserType' primary='true' sourcepath='somepakage/db/usertypes/XStreamUserType.java' sourcefile='XStreamUserType.java' end='76'>
       <Message>At XStreamUserType.java:[line 76]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MT_CORRECTNESS' instanceHash='9b40d3bceffe850e64c00078ddebc8f5' instanceOccurrenceNum='0' priority='3' abbrev='IS' type='IS2_INCONSISTENT_SYNC' instanceOccurrenceMax='0'>
     <ShortMessage>Inconsistent synchronization</ShortMessage>
-    <LongMessage>Inconsistent synchronization of com.aconex.lockable.LockableSupport.lockedPermanently; locked 66% of
+    <LongMessage>Inconsistent synchronization of somepakage.lockable.LockableSupport.lockedPermanently; locked 66% of
       time
     </LongMessage>
-    <Class classname='com.aconex.lockable.LockableSupport' primary='true'>
-      <SourceLine start='13' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' sourcefile='LockableSupport.java' end='77'>
+    <Class classname='somepakage.lockable.LockableSupport' primary='true'>
+      <SourceLine start='13' classname='somepakage.lockable.LockableSupport' sourcepath='somepakage/lockable/LockableSupport.java' sourcefile='LockableSupport.java' end='77'>
         <Message>At LockableSupport.java:[lines 13-77]</Message>
       </SourceLine>
-      <Message>In class com.aconex.lockable.LockableSupport</Message>
+      <Message>In class somepakage.lockable.LockableSupport</Message>
     </Class>
-    <Field isStatic='false' classname='com.aconex.lockable.LockableSupport' name='lockedPermanently' primary='true' signature='Z'>
-      <SourceLine classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' sourcefile='LockableSupport.java'>
+    <Field isStatic='false' classname='somepakage.lockable.LockableSupport' name='lockedPermanently' primary='true' signature='Z'>
+      <SourceLine classname='somepakage.lockable.LockableSupport' sourcepath='somepakage/lockable/LockableSupport.java' sourcefile='LockableSupport.java'>
         <Message>In LockableSupport.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.lockable.LockableSupport.lockedPermanently</Message>
+      <Message>Field somepakage.lockable.LockableSupport.lockedPermanently</Message>
     </Field>
     <Int value='66' role='INT_SYNC_PERCENT'>
       <Message>Synchronized 66% of the time</Message>
     </Int>
-    <SourceLine endBytecode='1' startBytecode='1' start='34' classname='com.aconex.lockable.LockableSupport' primary='true' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_UNSYNC_ACCESS' sourcefile='LockableSupport.java' end='34'>
+    <SourceLine endBytecode='1' startBytecode='1' start='34' classname='somepakage.lockable.LockableSupport' primary='true' sourcepath='somepakage/lockable/LockableSupport.java' role='SOURCE_LINE_UNSYNC_ACCESS' sourcefile='LockableSupport.java' end='34'>
       <Message>Unsynchronized access at LockableSupport.java:[line 34]</Message>
     </SourceLine>
-    <SourceLine endBytecode='2' startBytecode='2' start='50' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='50'>
+    <SourceLine endBytecode='2' startBytecode='2' start='50' classname='somepakage.lockable.LockableSupport' sourcepath='somepakage/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='50'>
       <Message>Synchronized access at LockableSupport.java:[line 50]</Message>
     </SourceLine>
-    <SourceLine endBytecode='11' startBytecode='11' start='15' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='15'>
+    <SourceLine endBytecode='11' startBytecode='11' start='15' classname='somepakage.lockable.LockableSupport' sourcepath='somepakage/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='15'>
       <Message>Synchronized access at LockableSupport.java:[line 15]</Message>
     </SourceLine>
-    <SourceLine endBytecode='1' startBytecode='1' start='61' classname='com.aconex.lockable.LockableSupport' sourcepath='com/aconex/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='61'>
+    <SourceLine endBytecode='1' startBytecode='1' start='61' classname='somepakage.lockable.LockableSupport' sourcepath='somepakage/lockable/LockableSupport.java' role='SOURCE_LINE_SYNC_ACCESS' sourcefile='LockableSupport.java' end='61'>
       <Message>Synchronized access at LockableSupport.java:[line 61]</Message>
     </SourceLine>
     <Property name='edu.umd.cs.findbugs.detect.InconsistentSyncWarningProperty.ONLY_UNSYNC_IN_GETTERS' value='true'></Property>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='7450e7e4f7615faea8e7c626fd718cd5' instanceOccurrenceNum='0' priority='2' abbrev='Se' type='SE_INNER_CLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Serializable inner class</ShortMessage>
-    <LongMessage>com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate is serializable and an inner class
+    <LongMessage>somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate is serializable and an inner class
     </LongMessage>
-    <Class classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
-      <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
+    <Class classname='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
+      <SourceLine start='156' classname='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepakage/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
         <Message>At XMLElement.java:[lines 156-175]</Message>
       </SourceLine>
-      <Message>In class com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
+      <Message>In class somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
     </Class>
-    <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
+    <SourceLine start='156' classname='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepakage/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
       <Message>At XMLElement.java:[lines 156-175]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='PERFORMANCE' instanceHash='fcc958dd49589a3a85dab990634c275c' instanceOccurrenceNum='0' priority='2' abbrev='SIC' type='SIC_INNER_SHOULD_BE_STATIC' instanceOccurrenceMax='0'>
     <ShortMessage>Should be a static inner class</ShortMessage>
-    <LongMessage>Should com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate be a _static_ inner class?
+    <LongMessage>Should somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate be a _static_ inner class?
     </LongMessage>
-    <Class classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
-      <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
+    <Class classname='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' primary='true'>
+      <SourceLine start='156' classname='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepakage/pdf/jobTicket/XMLElement.java' sourcefile='XMLElement.java' end='175'>
         <Message>At XMLElement.java:[lines 156-175]</Message>
       </SourceLine>
-      <Message>In class com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
+      <Message>In class somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate</Message>
     </Class>
-    <SourceLine start='156' classname='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='com/aconex/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
+    <SourceLine start='156' classname='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' sourcepath='somepakage/pdf/jobTicket/XMLElement.java' synthetic='true' sourcefile='XMLElement.java' end='175'>
       <Message>At XMLElement.java:[lines 156-175]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='12b2510f81587883108009bfd6cf8631' instanceOccurrenceNum='0' priority='1' abbrev='Nm' type='NM_SAME_SIMPLE_NAME_AS_SUPERCLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Class names shouldn't shadow simple name of superclass</ShortMessage>
-    <LongMessage>The class name com.aconex.utilities.BeanUtils shadows the simple name of the superclass
+    <LongMessage>The class name somepakage.utilities.BeanUtils shadows the simple name of the superclass
       org.apache.commons.beanutils.BeanUtils
     </LongMessage>
-    <Class classname='com.aconex.utilities.BeanUtils' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.BeanUtils' sourcepath='com/aconex/utilities/BeanUtils.java' sourcefile='BeanUtils.java' end='32'>
+    <Class classname='somepakage.utilities.BeanUtils' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.BeanUtils' sourcepath='somepakage/utilities/BeanUtils.java' sourcefile='BeanUtils.java' end='32'>
         <Message>At BeanUtils.java:[lines 13-32]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.BeanUtils</Message>
+      <Message>In class somepakage.utilities.BeanUtils</Message>
     </Class>
     <Class classname='org.apache.commons.beanutils.BeanUtils'>
       <SourceLine start='42' classname='org.apache.commons.beanutils.BeanUtils' sourcepath='org/apache/commons/beanutils/BeanUtils.java' sourcefile='BeanUtils.java' end='314'>
@@ -414,20 +215,20 @@
       </SourceLine>
       <Message>In class org.apache.commons.beanutils.BeanUtils</Message>
     </Class>
-    <SourceLine start='13' classname='com.aconex.utilities.BeanUtils' sourcepath='com/aconex/utilities/BeanUtils.java' synthetic='true' sourcefile='BeanUtils.java' end='32'>
+    <SourceLine start='13' classname='somepakage.utilities.BeanUtils' sourcepath='somepakage/utilities/BeanUtils.java' synthetic='true' sourcefile='BeanUtils.java' end='32'>
       <Message>At BeanUtils.java:[lines 13-32]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='291b69d322e177eaaa3f2b8ab2ac80f' instanceOccurrenceNum='0' priority='1' abbrev='Nm' type='NM_SAME_SIMPLE_NAME_AS_SUPERCLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Class names shouldn't shadow simple name of superclass</ShortMessage>
-    <LongMessage>The class name com.aconex.utilities.NumberUtils shadows the simple name of the superclass
+    <LongMessage>The class name somepakage.utilities.NumberUtils shadows the simple name of the superclass
       org.apache.commons.lang.math.NumberUtils
     </LongMessage>
-    <Class classname='com.aconex.utilities.NumberUtils' primary='true'>
-      <SourceLine start='3' classname='com.aconex.utilities.NumberUtils' sourcepath='com/aconex/utilities/NumberUtils.java' sourcefile='NumberUtils.java' end='19'>
+    <Class classname='somepakage.utilities.NumberUtils' primary='true'>
+      <SourceLine start='3' classname='somepakage.utilities.NumberUtils' sourcepath='somepakage/utilities/NumberUtils.java' sourcefile='NumberUtils.java' end='19'>
         <Message>At NumberUtils.java:[lines 3-19]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.NumberUtils</Message>
+      <Message>In class somepakage.utilities.NumberUtils</Message>
     </Class>
     <Class classname='org.apache.commons.lang.math.NumberUtils'>
       <SourceLine start='41' classname='org.apache.commons.lang.math.NumberUtils' sourcepath='org/apache/commons/lang/math/NumberUtils.java' sourcefile='NumberUtils.java' end='1479'>
@@ -435,20 +236,20 @@
       </SourceLine>
       <Message>In class org.apache.commons.lang.math.NumberUtils</Message>
     </Class>
-    <SourceLine start='3' classname='com.aconex.utilities.NumberUtils' sourcepath='com/aconex/utilities/NumberUtils.java' synthetic='true' sourcefile='NumberUtils.java' end='19'>
+    <SourceLine start='3' classname='somepakage.utilities.NumberUtils' sourcepath='somepakage/utilities/NumberUtils.java' synthetic='true' sourcefile='NumberUtils.java' end='19'>
       <Message>At NumberUtils.java:[lines 3-19]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='4df0695eacb85cd9e071c34b0a4d9870' instanceOccurrenceNum='0' priority='1' abbrev='Nm' type='NM_SAME_SIMPLE_NAME_AS_SUPERCLASS' instanceOccurrenceMax='0'>
     <ShortMessage>Class names shouldn't shadow simple name of superclass</ShortMessage>
-    <LongMessage>The class name com.aconex.utilities.StringEscapeUtils shadows the simple name of the superclass
+    <LongMessage>The class name somepakage.utilities.StringEscapeUtils shadows the simple name of the superclass
       org.apache.commons.lang.StringEscapeUtils
     </LongMessage>
-    <Class classname='com.aconex.utilities.StringEscapeUtils' primary='true'>
-      <SourceLine start='9' classname='com.aconex.utilities.StringEscapeUtils' sourcepath='com/aconex/utilities/StringEscapeUtils.java' sourcefile='StringEscapeUtils.java' end='35'>
+    <Class classname='somepakage.utilities.StringEscapeUtils' primary='true'>
+      <SourceLine start='9' classname='somepakage.utilities.StringEscapeUtils' sourcepath='somepakage/utilities/StringEscapeUtils.java' sourcefile='StringEscapeUtils.java' end='35'>
         <Message>At StringEscapeUtils.java:[lines 9-35]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.StringEscapeUtils</Message>
+      <Message>In class somepakage.utilities.StringEscapeUtils</Message>
     </Class>
     <Class classname='org.apache.commons.lang.StringEscapeUtils'>
       <SourceLine start='45' classname='org.apache.commons.lang.StringEscapeUtils' sourcepath='org/apache/commons/lang/StringEscapeUtils.java' sourcefile='StringEscapeUtils.java' end='858'>
@@ -456,105 +257,105 @@
       </SourceLine>
       <Message>In class org.apache.commons.lang.StringEscapeUtils</Message>
     </Class>
-    <SourceLine start='9' classname='com.aconex.utilities.StringEscapeUtils' sourcepath='com/aconex/utilities/StringEscapeUtils.java' synthetic='true' sourcefile='StringEscapeUtils.java' end='35'>
+    <SourceLine start='9' classname='somepakage.utilities.StringEscapeUtils' sourcepath='somepakage/utilities/StringEscapeUtils.java' synthetic='true' sourcefile='StringEscapeUtils.java' end='35'>
       <Message>At StringEscapeUtils.java:[lines 9-35]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MALICIOUS_CODE' instanceHash='14eaa16dd47838de6319b1b27953b534' instanceOccurrenceNum='0' priority='2' abbrev='EI2' type='EI_EXPOSE_REP2' instanceOccurrenceMax='0'>
     <ShortMessage>May expose internal representation by incorporating reference to mutable object</ShortMessage>
-    <LongMessage>com.aconex.utilities.TimingStatistics.recordEvent(Date) may expose internal representation by storing
+    <LongMessage>somepakage.utilities.TimingStatistics.recordEvent(Date) may expose internal representation by storing
       an externally mutable object into TimingStatistics.lastEventStart
     </LongMessage>
-    <Class classname='com.aconex.utilities.TimingStatistics' primary='true'>
-      <SourceLine start='25' classname='com.aconex.utilities.TimingStatistics' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='121'>
+    <Class classname='somepakage.utilities.TimingStatistics' primary='true'>
+      <SourceLine start='25' classname='somepakage.utilities.TimingStatistics' sourcepath='somepakage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='121'>
         <Message>At TimingStatistics.java:[lines 25-121]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.TimingStatistics</Message>
+      <Message>In class somepakage.utilities.TimingStatistics</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.TimingStatistics' name='recordEvent' primary='true' signature='(Ljava/util/Date;)V'>
-      <SourceLine endBytecode='212' startBytecode='0' start='86' classname='com.aconex.utilities.TimingStatistics' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='94'></SourceLine>
-      <Message>In method com.aconex.utilities.TimingStatistics.recordEvent(Date)</Message>
+    <Method isStatic='false' classname='somepakage.utilities.TimingStatistics' name='recordEvent' primary='true' signature='(Ljava/util/Date;)V'>
+      <SourceLine endBytecode='212' startBytecode='0' start='86' classname='somepakage.utilities.TimingStatistics' sourcepath='somepakage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='94'></SourceLine>
+      <Message>In method somepakage.utilities.TimingStatistics.recordEvent(Date)</Message>
     </Method>
-    <Field isStatic='false' classname='com.aconex.utilities.TimingStatistics' name='lastEventStart' primary='true' signature='Ljava/util/Date;'>
-      <SourceLine classname='com.aconex.utilities.TimingStatistics' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java'>
+    <Field isStatic='false' classname='somepakage.utilities.TimingStatistics' name='lastEventStart' primary='true' signature='Ljava/util/Date;'>
+      <SourceLine classname='somepakage.utilities.TimingStatistics' sourcepath='somepakage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java'>
         <Message>In TimingStatistics.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.utilities.TimingStatistics.lastEventStart</Message>
+      <Message>Field somepakage.utilities.TimingStatistics.lastEventStart</Message>
     </Field>
     <LocalVariable register='1' name='eventStart' pc='68' role='LOCAL_VARIABLE_NAMED'>
       <Message>Local variable named eventStart</Message>
     </LocalVariable>
-    <SourceLine endBytecode='68' startBytecode='68' start='92' classname='com.aconex.utilities.TimingStatistics' primary='true' sourcepath='com/aconex/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='92'>
+    <SourceLine endBytecode='68' startBytecode='68' start='92' classname='somepakage.utilities.TimingStatistics' primary='true' sourcepath='somepakage/utilities/TimingStatistics.java' sourcefile='TimingStatistics.java' end='92'>
       <Message>At TimingStatistics.java:[line 92]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='37142248cb7bd8f07c0a7bc2743eb416' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
-    <LongMessage>Exception is caught when Exception is not thrown in com.aconex.utilities.URLUtils.isDir(String)
+    <LongMessage>Exception is caught when Exception is not thrown in somepakage.utilities.URLUtils.isDir(String)
     </LongMessage>
-    <Class classname='com.aconex.utilities.URLUtils' primary='true'>
-      <SourceLine start='22' classname='com.aconex.utilities.URLUtils' sourcepath='com/aconex/utilities/URLUtils.java' sourcefile='URLUtils.java' end='346'>
+    <Class classname='somepakage.utilities.URLUtils' primary='true'>
+      <SourceLine start='22' classname='somepakage.utilities.URLUtils' sourcepath='somepakage/utilities/URLUtils.java' sourcefile='URLUtils.java' end='346'>
         <Message>At URLUtils.java:[lines 22-346]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.URLUtils</Message>
+      <Message>In class somepakage.utilities.URLUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.URLUtils' name='isDir' primary='true' signature='(Ljava/lang/String;)Z'>
-      <SourceLine endBytecode='280' startBytecode='0' start='217' classname='com.aconex.utilities.URLUtils' sourcepath='com/aconex/utilities/URLUtils.java' sourcefile='URLUtils.java' end='237'></SourceLine>
-      <Message>In method com.aconex.utilities.URLUtils.isDir(String)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.URLUtils' name='isDir' primary='true' signature='(Ljava/lang/String;)Z'>
+      <SourceLine endBytecode='280' startBytecode='0' start='217' classname='somepakage.utilities.URLUtils' sourcepath='somepakage/utilities/URLUtils.java' sourcefile='URLUtils.java' end='237'></SourceLine>
+      <Message>In method somepakage.utilities.URLUtils.isDir(String)</Message>
     </Method>
-    <SourceLine endBytecode='86' startBytecode='86' start='235' classname='com.aconex.utilities.URLUtils' primary='true' sourcepath='com/aconex/utilities/URLUtils.java' sourcefile='URLUtils.java' end='235'>
+    <SourceLine endBytecode='86' startBytecode='86' start='235' classname='somepakage.utilities.URLUtils' primary='true' sourcepath='somepakage/utilities/URLUtils.java' sourcefile='URLUtils.java' end='235'>
       <Message>At URLUtils.java:[line 235]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='392eae7778bff9ffdf48af0f265c5898' instanceOccurrenceNum='0' priority='3' abbrev='REC' type='REC_CATCH_EXCEPTION' instanceOccurrenceMax='0'>
     <ShortMessage>Exception is caught when Exception is not thrown</ShortMessage>
     <LongMessage>Exception is caught when Exception is not thrown in
-      com.aconex.utilities.XMLUtils.addElement(StringBuffer, String, Date)
+      somepakage.utilities.XMLUtils.addElement(StringBuffer, String, Date)
     </LongMessage>
-    <Class classname='com.aconex.utilities.XMLUtils' primary='true'>
-      <SourceLine start='14' classname='com.aconex.utilities.XMLUtils' sourcepath='com/aconex/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='66'>
+    <Class classname='somepakage.utilities.XMLUtils' primary='true'>
+      <SourceLine start='14' classname='somepakage.utilities.XMLUtils' sourcepath='somepakage/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='66'>
         <Message>At XMLUtils.java:[lines 14-66]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.XMLUtils</Message>
+      <Message>In class somepakage.utilities.XMLUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.XMLUtils' name='addElement' primary='true' signature='(Ljava/lang/StringBuffer;Ljava/lang/String;Ljava/util/Date;)V'>
-      <SourceLine endBytecode='229' startBytecode='0' start='46' classname='com.aconex.utilities.XMLUtils' sourcepath='com/aconex/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='54'></SourceLine>
-      <Message>In method com.aconex.utilities.XMLUtils.addElement(StringBuffer, String, Date)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.XMLUtils' name='addElement' primary='true' signature='(Ljava/lang/StringBuffer;Ljava/lang/String;Ljava/util/Date;)V'>
+      <SourceLine endBytecode='229' startBytecode='0' start='46' classname='somepakage.utilities.XMLUtils' sourcepath='somepakage/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='54'></SourceLine>
+      <Message>In method somepakage.utilities.XMLUtils.addElement(StringBuffer, String, Date)</Message>
     </Method>
-    <SourceLine endBytecode='62' startBytecode='62' start='51' classname='com.aconex.utilities.XMLUtils' primary='true' sourcepath='com/aconex/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='51'>
+    <SourceLine endBytecode='62' startBytecode='62' start='51' classname='somepakage.utilities.XMLUtils' primary='true' sourcepath='somepakage/utilities/XMLUtils.java' sourcefile='XMLUtils.java' end='51'>
       <Message>At XMLUtils.java:[line 51]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='2ca213d29bd65438d6c98b9f0fb0acee' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserProperties' primary='true'>
-      <SourceLine start='34' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
+    <Class classname='somepakage.utilities.browser.BrowserProperties' primary='true'>
+      <SourceLine start='34' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
         <Message>At BrowserProperties.java:[lines 34-222]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserProperties</Message>
+      <Message>In class somepakage.utilities.browser.BrowserProperties</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.browser.BrowserProperties' name='setUserAgent' primary='true' signature='(Ljava/lang/String;)V'>
-      <SourceLine endBytecode='64' startBytecode='0' start='63' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='64'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserProperties.setUserAgent(String)</Message>
+    <Method isStatic='false' classname='somepakage.utilities.browser.BrowserProperties' name='setUserAgent' primary='true' signature='(Ljava/lang/String;)V'>
+      <SourceLine endBytecode='64' startBytecode='0' start='63' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='64'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserProperties.setUserAgent(String)</Message>
     </Method>
-    <SourceLine endBytecode='2' startBytecode='2' start='63' classname='com.aconex.utilities.browser.BrowserProperties' primary='true' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='63'>
+    <SourceLine endBytecode='2' startBytecode='2' start='63' classname='somepakage.utilities.browser.BrowserProperties' primary='true' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='63'>
       <Message>At BrowserProperties.java:[line 63]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='e9cbb778c764ba18611328bf751e682f' instanceOccurrenceNum='0' priority='3' abbrev='ES' type='ES_COMPARING_STRINGS_WITH_EQ' instanceOccurrenceMax='0'>
     <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
-    <LongMessage>Comparison of String objects using == or != in com.aconex.utilities.browser.BrowserProperties.setName()
+    <LongMessage>Comparison of String objects using == or != in somepakage.utilities.browser.BrowserProperties.setName()
     </LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserProperties' primary='true'>
-      <SourceLine start='34' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
+    <Class classname='somepakage.utilities.browser.BrowserProperties' primary='true'>
+      <SourceLine start='34' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
         <Message>At BrowserProperties.java:[lines 34-222]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserProperties</Message>
+      <Message>In class somepakage.utilities.browser.BrowserProperties</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.browser.BrowserProperties' name='setName' primary='true' signature='()V'>
-      <SourceLine endBytecode='45' startBytecode='0' start='88' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='101'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserProperties.setName()</Message>
+    <Method isStatic='false' classname='somepakage.utilities.browser.BrowserProperties' name='setName' primary='true' signature='()V'>
+      <SourceLine endBytecode='45' startBytecode='0' start='88' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='101'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserProperties.setName()</Message>
     </Method>
     <Type descriptor='Ljava/lang/String;' role='TYPE_FOUND'>
       <SourceLine start='92' classname='java.lang.String' sourcepath='java/lang/String.java' sourcefile='String.java' end='2973'>
@@ -562,16 +363,16 @@
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
-    <SourceLine endBytecode='6' startBytecode='6' start='88' classname='com.aconex.utilities.browser.BrowserProperties' primary='true' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='88'>
+    <SourceLine endBytecode='6' startBytecode='6' start='88' classname='somepakage.utilities.browser.BrowserProperties' primary='true' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='88'>
       <Message>At BrowserProperties.java:[line 88]</Message>
     </SourceLine>
-    <SourceLine endBytecode='24' startBytecode='24' start='90' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='90'>
+    <SourceLine endBytecode='24' startBytecode='24' start='90' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='90'>
       <Message>Another occurrence at BrowserProperties.java:[line 90]</Message>
     </SourceLine>
-    <SourceLine endBytecode='42' startBytecode='42' start='92' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='92'>
+    <SourceLine endBytecode='42' startBytecode='42' start='92' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='92'>
       <Message>Another occurrence at BrowserProperties.java:[line 92]</Message>
     </SourceLine>
-    <SourceLine endBytecode='82' startBytecode='82' start='96' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='96'>
+    <SourceLine endBytecode='82' startBytecode='82' start='96' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' role='SOURCE_LINE_ANOTHER_INSTANCE' sourcefile='BrowserProperties.java' end='96'>
       <Message>Another occurrence at BrowserProperties.java:[line 96]</Message>
     </SourceLine>
     <Property name='edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.STATIC_AND_UNKNOWN' value='true'></Property>
@@ -579,17 +380,17 @@
   <BugInstance category='BAD_PRACTICE' instanceHash='2336d7e503ab8b66bd8bfc2cbcc0a2ae' instanceOccurrenceNum='0' priority='3' abbrev='ES' type='ES_COMPARING_STRINGS_WITH_EQ' instanceOccurrenceMax='0'>
     <ShortMessage>Comparison of String objects using == or !=</ShortMessage>
     <LongMessage>Comparison of String objects using == or != in
-      com.aconex.utilities.browser.BrowserProperties.setVersion()
+      somepakage.utilities.browser.BrowserProperties.setVersion()
     </LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserProperties' primary='true'>
-      <SourceLine start='34' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
+    <Class classname='somepakage.utilities.browser.BrowserProperties' primary='true'>
+      <SourceLine start='34' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='222'>
         <Message>At BrowserProperties.java:[lines 34-222]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserProperties</Message>
+      <Message>In class somepakage.utilities.browser.BrowserProperties</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.browser.BrowserProperties' name='setVersion' primary='true' signature='()V'>
-      <SourceLine endBytecode='50' startBytecode='0' start='114' classname='com.aconex.utilities.browser.BrowserProperties' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='122'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserProperties.setVersion()</Message>
+    <Method isStatic='false' classname='somepakage.utilities.browser.BrowserProperties' name='setVersion' primary='true' signature='()V'>
+      <SourceLine endBytecode='50' startBytecode='0' start='114' classname='somepakage.utilities.browser.BrowserProperties' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='122'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserProperties.setVersion()</Message>
     </Method>
     <Type descriptor='Ljava/lang/String;' role='TYPE_FOUND'>
       <SourceLine start='92' classname='java.lang.String' sourcepath='java/lang/String.java' sourcefile='String.java' end='2973'>
@@ -597,7 +398,7 @@
       </SourceLine>
       <Message>Actual type String</Message>
     </Type>
-    <SourceLine endBytecode='6' startBytecode='6' start='114' classname='com.aconex.utilities.browser.BrowserProperties' primary='true' sourcepath='com/aconex/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='114'>
+    <SourceLine endBytecode='6' startBytecode='6' start='114' classname='somepakage.utilities.browser.BrowserProperties' primary='true' sourcepath='somepakage/utilities/browser/BrowserProperties.java' sourcefile='BrowserProperties.java' end='114'>
       <Message>At BrowserProperties.java:[line 114]</Message>
     </SourceLine>
     <Property name='edu.umd.cs.findbugs.detect.RefComparisonWarningProperty.STATIC_AND_UNKNOWN' value='true'></Property>
@@ -605,213 +406,213 @@
   <BugInstance category='I18N' instanceHash='434646ef370f5fe0483988cb6e01db45' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='139' startBytecode='0' start='60' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='75'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_ie' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='139' startBytecode='0' start='60' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='75'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_ie(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='70' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='70'>
+    <SourceLine endBytecode='22' startBytecode='22' start='70' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='70'>
       <Message>At BrowserSniffer.java:[line 70]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='45d59ba7b7f5f6080737550f66bd1065' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='87' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='102'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie_4(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_ie_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='87' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='102'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_ie_4(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='97' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='97'>
+    <SourceLine endBytecode='22' startBytecode='22' start='97' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='97'>
       <Message>At BrowserSniffer.java:[line 97]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='db1c2266ed743a840341d0ede66c9eb6' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='114' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='129'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie_5(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_ie_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='114' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='129'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_ie_5(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='124' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='124'>
+    <SourceLine endBytecode='22' startBytecode='22' start='124' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='124'>
       <Message>At BrowserSniffer.java:[line 124]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='35ed017a63e7e679c93a91f4976f110f' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ie_5_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='141' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='156'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ie_5_5(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_ie_5_5' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='141' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='156'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_ie_5_5(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='151' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='151'>
+    <SourceLine endBytecode='22' startBytecode='22' start='151' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='151'>
       <Message>At BrowserSniffer.java:[line 151]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='e58cfa76400f8cc05ff07751d03c5978' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_mozilla' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='191' startBytecode='0' start='183' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='201'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_mozilla(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_mozilla' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='191' startBytecode='0' start='183' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='201'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_mozilla(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='193' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='193'>
+    <SourceLine endBytecode='22' startBytecode='22' start='193' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='193'>
       <Message>At BrowserSniffer.java:[line 193]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='62a48ebb79f66fd63b5069188cd1b48f' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_mozilla_1_3_up' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='218' startBytecode='0' start='214' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='240'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_mozilla_1_3_up(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_mozilla_1_3_up' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='218' startBytecode='0' start='214' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='240'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_mozilla_1_3_up(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='224' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='224'>
+    <SourceLine endBytecode='22' startBytecode='22' start='224' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='224'>
       <Message>At BrowserSniffer.java:[line 224]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='61249ef7ad4252e18b8b8af7f3d9d7d' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_ns_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='146' startBytecode='0' start='250' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='265'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_ns_4(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_ns_4' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='146' startBytecode='0' start='250' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='265'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_ns_4(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='260' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='260'>
+    <SourceLine endBytecode='22' startBytecode='22' start='260' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='260'>
       <Message>At BrowserSniffer.java:[line 260]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='I18N' instanceHash='2bf6249e3fdf04fa0811caa16aeca12c' instanceOccurrenceNum='0' priority='3' abbrev='Dm' type='DM_CONVERT_CASE' instanceOccurrenceMax='0'>
     <ShortMessage>Consider using Locale parameterized version of invoked method</ShortMessage>
     <LongMessage>Use of non-localized String.toUpperCase() or String.toLowerCase</LongMessage>
-    <Class classname='com.aconex.utilities.browser.BrowserSniffer' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
+    <Class classname='somepakage.utilities.browser.BrowserSniffer' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'>
         <Message>At BrowserSniffer.java:[lines 13-305]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.browser.BrowserSniffer</Message>
+      <Message>In class somepakage.utilities.browser.BrowserSniffer</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.utilities.browser.BrowserSniffer' name='is_wml' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
-      <SourceLine endBytecode='139' startBytecode='0' start='290' classname='com.aconex.utilities.browser.BrowserSniffer' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'></SourceLine>
-      <Message>In method com.aconex.utilities.browser.BrowserSniffer.is_wml(HttpServletRequest)</Message>
+    <Method isStatic='true' classname='somepakage.utilities.browser.BrowserSniffer' name='is_wml' primary='true' signature='(Ljavax/servlet/http/HttpServletRequest;)Z'>
+      <SourceLine endBytecode='139' startBytecode='0' start='290' classname='somepakage.utilities.browser.BrowserSniffer' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='305'></SourceLine>
+      <Message>In method somepakage.utilities.browser.BrowserSniffer.is_wml(HttpServletRequest)</Message>
     </Method>
-    <SourceLine endBytecode='22' startBytecode='22' start='300' classname='com.aconex.utilities.browser.BrowserSniffer' primary='true' sourcepath='com/aconex/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='300'>
+    <SourceLine endBytecode='22' startBytecode='22' start='300' classname='somepakage.utilities.browser.BrowserSniffer' primary='true' sourcepath='somepakage/utilities/browser/BrowserSniffer.java' sourcefile='BrowserSniffer.java' end='300'>
       <Message>At BrowserSniffer.java:[line 300]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='SECURITY' instanceHash='5d7a3f985cc0b52663e723a6315706c1' instanceOccurrenceNum='0' priority='3' abbrev='SQL' type='SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE' instanceOccurrenceMax='0'>
     <ShortMessage>Nonconstant string passed to execute method on an SQL statement</ShortMessage>
-    <LongMessage>Method com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
+    <LongMessage>Method somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
       passes a nonconstant String to an execute method on an SQL statement
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true'>
-      <SourceLine start='239' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true'>
+      <SourceLine start='239' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'>
         <Message>At LoggingDriver.java:[lines 239-351]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler</Message>
+      <Message>In class somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' name='execute' primary='true' signature='(Ljava/sql/Connection;Ljava/lang/String;)V'>
-      <SourceLine endBytecode='17' startBytecode='0' start='344' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'></SourceLine>
-      <Message>In method com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
+    <Method isStatic='false' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler' name='execute' primary='true' signature='(Ljava/sql/Connection;Ljava/lang/String;)V'>
+      <SourceLine endBytecode='17' startBytecode='0' start='344' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='351'></SourceLine>
+      <Message>In method somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler.execute(Connection, String)
       </Message>
     </Method>
-    <SourceLine endBytecode='11' startBytecode='11' start='347' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='347'>
+    <SourceLine endBytecode='11' startBytecode='11' start='347' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler' primary='true' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='347'>
       <Message>At LoggingDriver.java:[line 347]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='PERFORMANCE' instanceHash='28cd6f1b56d5733fc52774acc7aa6829' instanceOccurrenceNum='0' priority='2' abbrev='SIC' type='SIC_INNER_SHOULD_BE_STATIC' instanceOccurrenceMax='0'>
     <ShortMessage>Should be a static inner class</ShortMessage>
-    <LongMessage>Should com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler be
+    <LongMessage>Should somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler be
       a _static_ inner class?
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' primary='true'>
-      <SourceLine start='431' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='455'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' primary='true'>
+      <SourceLine start='431' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='455'>
         <Message>At LoggingDriver.java:[lines 431-455]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler
+      <Message>In class somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler
       </Message>
     </Class>
-    <SourceLine start='431' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java' end='455'>
+    <SourceLine start='431' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' sourcepath='somepakage/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java' end='455'>
       <Message>At LoggingDriver.java:[lines 431-455]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='9c8820b5f78e266093334b5a3dad842' instanceOccurrenceNum='0' priority='2' abbrev='NP' type='NP_LOAD_OF_KNOWN_NULL_VALUE' instanceOccurrenceMax='0'>
     <ShortMessage>Load of known null value</ShortMessage>
     <LongMessage>Load of known null value in
-      com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
+      somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
       Method, Object[])
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true'>
-      <SourceLine start='366' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='417'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true'>
+      <SourceLine start='366' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='417'>
         <Message>At LoggingDriver.java:[lines 366-417]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler
+      <Message>In class somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler
       </Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' name='invoke' primary='true' signature='(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;'>
-      <SourceLine endBytecode='93' startBytecode='0' start='375' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='397'></SourceLine>
+    <Method isStatic='false' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' name='invoke' primary='true' signature='(Ljava/lang/Object;Ljava/lang/reflect/Method;[Ljava/lang/Object;)Ljava/lang/Object;'>
+      <SourceLine endBytecode='93' startBytecode='0' start='375' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='397'></SourceLine>
       <Message>In method
-        com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
+        somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler.invoke(Object,
         Method, Object[])
       </Message>
     </Method>
-    <SourceLine endBytecode='125' startBytecode='125' start='387' classname='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='387'>
+    <SourceLine endBytecode='125' startBytecode='125' start='387' classname='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' primary='true' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='387'>
       <Message>At LoggingDriver.java:[line 387]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='94bcf06bfd79f5dd103bb7a6bb938892' instanceOccurrenceNum='0' priority='2' abbrev='ODR' type='ODR_OPEN_DATABASE_RESOURCE' instanceOccurrenceMax='0'>
     <ShortMessage>Method may fail to close database resource</ShortMessage>
-    <LongMessage>com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo() may fail to close
+    <LongMessage>somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo() may fail to close
       CallableStatement
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true'>
-      <SourceLine start='463' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='734'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true'>
+      <SourceLine start='463' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='734'>
         <Message>At LoggingDriver.java:[lines 463-734]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor</Message>
+      <Message>In class somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' name='getBlockingInfo' primary='true' signature='()Ljava/util/Map;'>
-      <SourceLine endBytecode='62' startBytecode='0' start='612' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='629'></SourceLine>
-      <Message>In method com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo()</Message>
+    <Method isStatic='false' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor' name='getBlockingInfo' primary='true' signature='()Ljava/util/Map;'>
+      <SourceLine endBytecode='62' startBytecode='0' start='612' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='629'></SourceLine>
+      <Message>In method somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor.getBlockingInfo()</Message>
     </Method>
     <Type descriptor='Ljava/sql/CallableStatement;' role='TYPE_CLOSEIT'>
       <SourceLine classname='java.sql.CallableStatement' sourcepath='java/sql/CallableStatement.java' sourcefile='CallableStatement.java'>
@@ -819,149 +620,149 @@
       </SourceLine>
       <Message>Need to close java.sql.CallableStatement</Message>
     </Type>
-    <SourceLine endBytecode='17' startBytecode='17' start='615' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='615'>
+    <SourceLine endBytecode='17' startBytecode='17' start='615' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor' primary='true' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='615'>
       <Message>At LoggingDriver.java:[line 615]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='STYLE' instanceHash='3ba68cb497350c301e4f7a74c85fe4a3' instanceOccurrenceNum='0' priority='3' abbrev='PZLA' type='PZLA_PREFER_ZERO_LENGTH_ARRAYS' instanceOccurrenceMax='0'>
     <ShortMessage>Consider returning a zero length array rather than null</ShortMessage>
     <LongMessage>Should
-      com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
+      somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
       LoggingDriver$LoggingDriverMonitor$WarningFilter) return a zero length array rather than null?
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
-      <SourceLine start='764' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
+      <SourceLine start='764' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
         <Message>At LoggingDriver.java:[lines 764-940]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
+      <Message>In class somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='collectWarningMessages' primary='true' signature='(Ljava/sql/SQLWarning;Lcom/aconex/utilities/db/LoggingDriver$LoggingDriverMonitor$WarningFilter;)[Ljava/lang/String;'>
-      <SourceLine endBytecode='214' startBytecode='0' start='863' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='877'></SourceLine>
+    <Method isStatic='false' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='collectWarningMessages' primary='true' signature='(Ljava/sql/SQLWarning;Lsomepakage/utilities/db/LoggingDriver$LoggingDriverMonitor$WarningFilter;)[Ljava/lang/String;'>
+      <SourceLine endBytecode='214' startBytecode='0' start='863' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='877'></SourceLine>
       <Message>In method
-        com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
+        somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.collectWarningMessages(SQLWarning,
         LoggingDriver$LoggingDriverMonitor$WarningFilter)
       </Message>
     </Method>
-    <SourceLine endBytecode='5' startBytecode='5' start='864' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='864'>
+    <SourceLine endBytecode='5' startBytecode='5' start='864' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='864'>
       <Message>At LoggingDriver.java:[line 864]</Message>
     </SourceLine>
-    <SourceLine endBytecode='52' startBytecode='52' start='875' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='875'>
+    <SourceLine endBytecode='52' startBytecode='52' start='875' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='875'>
       <Message>At LoggingDriver.java:[line 875]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MT_CORRECTNESS' instanceHash='dc100a165fd98ccc6c063768c0b60131' instanceOccurrenceNum='0' priority='3' abbrev='VO' type='VO_VOLATILE_REFERENCE_TO_ARRAY' instanceOccurrenceMax='0'>
     <ShortMessage>A volatile reference to an array doesn't treat the array elements as volatile</ShortMessage>
-    <LongMessage>com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData is a volatile reference to
+    <LongMessage>somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData is a volatile reference to
       an array; the array elements are non-volatile
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
-      <SourceLine start='764' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
+      <SourceLine start='764' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
         <Message>At LoggingDriver.java:[lines 764-940]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
+      <Message>In class somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
     </Class>
-    <Field isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='cpuData' primary='true' signature='[Ljava/lang/String;'>
-      <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
+    <Field isStatic='false' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='cpuData' primary='true' signature='[Ljava/lang/String;'>
+      <SourceLine classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
         <Message>In LoggingDriver.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData</Message>
+      <Message>Field somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.cpuData</Message>
     </Field>
-    <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
+    <SourceLine classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
       <Message>In LoggingDriver.java</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='MT_CORRECTNESS' instanceHash='101259f4738574d6cea384cfed745249' instanceOccurrenceNum='0' priority='3' abbrev='VO' type='VO_VOLATILE_REFERENCE_TO_ARRAY' instanceOccurrenceMax='0'>
     <ShortMessage>A volatile reference to an array doesn't treat the array elements as volatile</ShortMessage>
-    <LongMessage>com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData is a volatile reference to
+    <LongMessage>somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData is a volatile reference to
       an array; the array elements are non-volatile
     </LongMessage>
-    <Class classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
-      <SourceLine start='764' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
+    <Class classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' primary='true'>
+      <SourceLine start='764' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java' end='940'>
         <Message>At LoggingDriver.java:[lines 764-940]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
+      <Message>In class somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog</Message>
     </Class>
-    <Field isStatic='false' classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='ioData' primary='true' signature='[Ljava/lang/String;'>
-      <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
+    <Field isStatic='false' classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' name='ioData' primary='true' signature='[Ljava/lang/String;'>
+      <SourceLine classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' sourcefile='LoggingDriver.java'>
         <Message>In LoggingDriver.java</Message>
       </SourceLine>
-      <Message>Field com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData</Message>
+      <Message>Field somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog.ioData</Message>
     </Field>
-    <SourceLine classname='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='com/aconex/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
+    <SourceLine classname='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' sourcepath='somepakage/utilities/db/LoggingDriver.java' synthetic='true' sourcefile='LoggingDriver.java'>
       <Message>In LoggingDriver.java</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='32b4b89479a45ec3c7f2e49d03fdd5c2' instanceOccurrenceNum='0' priority='2' abbrev='Eq' type='EQ_COMPARETO_USE_OBJECT_EQUALS' instanceOccurrenceMax='0'>
     <ShortMessage>Class defines compareTo(...) and uses Object.equals()</ShortMessage>
-    <LongMessage>com.aconex.utilities.message.Message defines compareTo(Message) and uses Object.equals()</LongMessage>
-    <Class classname='com.aconex.utilities.message.Message' primary='true'>
-      <SourceLine start='13' classname='com.aconex.utilities.message.Message' sourcepath='com/aconex/utilities/message/Message.java' sourcefile='Message.java' end='55'>
+    <LongMessage>somepakage.utilities.message.Message defines compareTo(Message) and uses Object.equals()</LongMessage>
+    <Class classname='somepakage.utilities.message.Message' primary='true'>
+      <SourceLine start='13' classname='somepakage.utilities.message.Message' sourcepath='somepakage/utilities/message/Message.java' sourcefile='Message.java' end='55'>
         <Message>At Message.java:[lines 13-55]</Message>
       </SourceLine>
-      <Message>In class com.aconex.utilities.message.Message</Message>
+      <Message>In class somepakage.utilities.message.Message</Message>
     </Class>
-    <Method isStatic='false' classname='com.aconex.utilities.message.Message' name='compareTo' primary='true' signature='(Lcom/aconex/utilities/message/Message;)I'>
-      <SourceLine endBytecode='63' startBytecode='0' start='55' classname='com.aconex.utilities.message.Message' sourcepath='com/aconex/utilities/message/Message.java' sourcefile='Message.java' end='55'></SourceLine>
-      <Message>In method com.aconex.utilities.message.Message.compareTo(Message)</Message>
+    <Method isStatic='false' classname='somepakage.utilities.message.Message' name='compareTo' primary='true' signature='(Lsomepakage/utilities/message/Message;)I'>
+      <SourceLine endBytecode='63' startBytecode='0' start='55' classname='somepakage.utilities.message.Message' sourcepath='somepakage/utilities/message/Message.java' sourcefile='Message.java' end='55'></SourceLine>
+      <Message>In method somepakage.utilities.message.Message.compareTo(Message)</Message>
     </Method>
-    <SourceLine endBytecode='63' startBytecode='0' start='55' classname='com.aconex.utilities.message.Message' sourcepath='com/aconex/utilities/message/Message.java' synthetic='true' sourcefile='Message.java' end='55'>
+    <SourceLine endBytecode='63' startBytecode='0' start='55' classname='somepakage.utilities.message.Message' sourcepath='somepakage/utilities/message/Message.java' synthetic='true' sourcefile='Message.java' end='55'>
       <Message>At Message.java:[line 55]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='1814726daddb6450c0db73bc4162f85c' instanceOccurrenceNum='0' priority='3' abbrev='ISC' type='ISC_INSTANTIATE_STATIC_CLASS' instanceOccurrenceMax='2'>
     <ShortMessage>Needless instantiation of class that only supplies static methods</ShortMessage>
-    <LongMessage>Method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
+    <LongMessage>Method somepakage.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
       that only supplies static methods
     </LongMessage>
-    <Class classname='com.aconex.velocity.VelocityUtils' primary='true'>
-      <SourceLine start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
+    <Class classname='somepakage.velocity.VelocityUtils' primary='true'>
+      <SourceLine start='20' classname='somepakage.velocity.VelocityUtils' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
         <Message>At VelocityUtils.java:[lines 20-74]</Message>
       </SourceLine>
-      <Message>In class com.aconex.velocity.VelocityUtils</Message>
+      <Message>In class somepakage.velocity.VelocityUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
-      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
-      <Message>In method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
+    <Method isStatic='true' classname='somepakage.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
+      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='somepakage.velocity.VelocityUtils' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
+      <Message>In method somepakage.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
     </Method>
-    <SourceLine endBytecode='173' startBytecode='173' start='48' classname='com.aconex.velocity.VelocityUtils' primary='true' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='48'>
+    <SourceLine endBytecode='173' startBytecode='173' start='48' classname='somepakage.velocity.VelocityUtils' primary='true' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='48'>
       <Message>At VelocityUtils.java:[line 48]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='1814726daddb6450c0db73bc4162f85c' instanceOccurrenceNum='1' priority='3' abbrev='ISC' type='ISC_INSTANTIATE_STATIC_CLASS' instanceOccurrenceMax='2'>
     <ShortMessage>Needless instantiation of class that only supplies static methods</ShortMessage>
-    <LongMessage>Method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
+    <LongMessage>Method somepakage.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
       that only supplies static methods
     </LongMessage>
-    <Class classname='com.aconex.velocity.VelocityUtils' primary='true'>
-      <SourceLine start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
+    <Class classname='somepakage.velocity.VelocityUtils' primary='true'>
+      <SourceLine start='20' classname='somepakage.velocity.VelocityUtils' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
         <Message>At VelocityUtils.java:[lines 20-74]</Message>
       </SourceLine>
-      <Message>In class com.aconex.velocity.VelocityUtils</Message>
+      <Message>In class somepakage.velocity.VelocityUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
-      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
-      <Message>In method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
+    <Method isStatic='true' classname='somepakage.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
+      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='somepakage.velocity.VelocityUtils' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
+      <Message>In method somepakage.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
     </Method>
-    <SourceLine endBytecode='191' startBytecode='191' start='49' classname='com.aconex.velocity.VelocityUtils' primary='true' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='49'>
+    <SourceLine endBytecode='191' startBytecode='191' start='49' classname='somepakage.velocity.VelocityUtils' primary='true' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='49'>
       <Message>At VelocityUtils.java:[line 49]</Message>
     </SourceLine>
   </BugInstance>
   <BugInstance category='BAD_PRACTICE' instanceHash='1814726daddb6450c0db73bc4162f85c' instanceOccurrenceNum='2' priority='3' abbrev='ISC' type='ISC_INSTANTIATE_STATIC_CLASS' instanceOccurrenceMax='2'>
     <ShortMessage>Needless instantiation of class that only supplies static methods</ShortMessage>
-    <LongMessage>Method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
+    <LongMessage>Method somepakage.velocity.VelocityUtils.&lt;static initializer&gt;() needlessly instantiates a class
       that only supplies static methods
     </LongMessage>
-    <Class classname='com.aconex.velocity.VelocityUtils' primary='true'>
-      <SourceLine start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
+    <Class classname='somepakage.velocity.VelocityUtils' primary='true'>
+      <SourceLine start='20' classname='somepakage.velocity.VelocityUtils' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='74'>
         <Message>At VelocityUtils.java:[lines 20-74]</Message>
       </SourceLine>
-      <Message>In class com.aconex.velocity.VelocityUtils</Message>
+      <Message>In class somepakage.velocity.VelocityUtils</Message>
     </Class>
-    <Method isStatic='true' classname='com.aconex.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
-      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='com.aconex.velocity.VelocityUtils' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
-      <Message>In method com.aconex.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
+    <Method isStatic='true' classname='somepakage.velocity.VelocityUtils' name='&lt;clinit&gt;' primary='true' signature='()V'>
+      <SourceLine endBytecode='405' startBytecode='0' start='20' classname='somepakage.velocity.VelocityUtils' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='55'></SourceLine>
+      <Message>In method somepakage.velocity.VelocityUtils.&lt;static initializer&gt;()</Message>
     </Method>
-    <SourceLine endBytecode='209' startBytecode='209' start='50' classname='com.aconex.velocity.VelocityUtils' primary='true' sourcepath='com/aconex/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='50'>
+    <SourceLine endBytecode='209' startBytecode='209' start='50' classname='somepakage.velocity.VelocityUtils' primary='true' sourcepath='somepakage/velocity/VelocityUtils.java' sourcefile='VelocityUtils.java' end='50'>
       <Message>At VelocityUtils.java:[line 50]</Message>
     </SourceLine>
   </BugInstance>
@@ -1291,273 +1092,273 @@
     <MissingClass>org.apache.commons.discovery.tools.DiscoverClass</MissingClass>
   </Errors>
   <FindBugsSummary alloc_mbytes='1365.38' priority_2='11' gc_seconds='0.15' peak_mbytes='395.80' total_bugs='37' priority_3='23' referenced_classes='507' timestamp='Mon, 23 Aug 2010 16:39:40 +1000' total_classes='135' num_packages='19' total_size='3444' cpu_seconds='26.16' clock_seconds='8.91' vm_version='16.3-b01'>
-    <FileStats path='com/aconex/db/BulkOperationHandler.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/db/CompositeBulkOperationHandler.java' bugCount='0' size='26'></FileStats>
-    <FileStats path='com/aconex/db/DAO.java' bugCount='0' size='19'></FileStats>
-    <FileStats path='com/aconex/db/DatabaseConstants.java' bugCount='0' size='5'></FileStats>
-    <FileStats path='com/aconex/db/HibernateDAO.java' bugCount='0' size='295'></FileStats>
-    <FileStats path='com/aconex/db/JdbcDAO.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/db/JdbcSettingsMBean.java' bugCount='1' bugHash='c5e12ef8b4c3b5761631ee80aa03ba0a' size='20'></FileStats>
-    <FileStats path='com/aconex/db/KeyedPersistable.java' bugCount='0' size='2'></FileStats>
-    <FileStats path='com/aconex/db/LegacyHibernateFlushingDAO.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/db/LegacyService.java' bugCount='2' bugHash='12e55d926b38eb819d258c757ff8842d' size='73'></FileStats>
-    <FileStats path='com/aconex/db/OrderDirection.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/AconexInExpression.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/AconexLikeExpression.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/BaseInExpression.java' bugCount='1' bugHash='f98a9b1e595d46d6770b05fae4ec7e9a' size='35'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernateBulkOperationHandler.java' bugCount='0' size='58'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernateCallbackWithoutResult.java' bugCount='0' size='7'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernateKeyEqualityHelper.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/HibernatePausingBulkOperationHandler.java' bugCount='0' size='20'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/IdentifierInExpression.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/NativeSQLOrder.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/OptionalRestrictions.java' bugCount='0' size='33'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/OrderingUtils.java' bugCount='0' size='7'></FileStats>
-    <FileStats path='com/aconex/db/hibernate/Restrictions.java' bugCount='0' size='89'></FileStats>
-    <FileStats path='com/aconex/db/usertypes/KeyedEnumUserType.java' bugCount='1' bugHash='29ebc0e6cf8b9d964eead37d91cb6702' size='66'></FileStats>
-    <FileStats path='com/aconex/db/usertypes/XStreamUserType.java' bugCount='1' bugHash='c02a68e22c20663da99cecc766d4673c' size='37'></FileStats>
-    <FileStats path='com/aconex/lockable/Lockable.java' bugCount='0' size='7'></FileStats>
-    <FileStats path='com/aconex/lockable/LockableSupport.java' bugCount='1' bugHash='84009006b1915ceafcb90f3f55754296' size='29'></FileStats>
-    <FileStats path='com/aconex/lockable/LockedException.java' bugCount='0' size='8'></FileStats>
-    <FileStats path='com/aconex/monitoring/MonitoredBeanPredicates.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/monitoring/RequestId.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/monitoring/TimedRunnable.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/pdf/jobTicket/XMLElement.java' bugCount='2' bugHash='b6186363a00367c77f5236cff985d159' size='68'></FileStats>
-    <FileStats path='com/aconex/security/util/PhoneticUtils.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/specification/OrSpecification.java' bugCount='0' size='10'></FileStats>
-    <FileStats path='com/aconex/specification/Specification.java' bugCount='0' size='2'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/CollectionMatchers.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsAnnotatedWithMatcher.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsCollectionContainingInAnyOrderMatcher.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsDeeplySerializableMatcher.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsImmutableMatcher.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsListContainingInOrderMatcher.java' bugCount='0' size='17'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsListEmptyMatcher.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsMapEmptyMatcher.java' bugCount='0' size='9'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsMemberPackageProtectedMatcher.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsMemberPublicMatcher.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsOfLengthMatcher.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsTransactionalMatcher.java' bugCount='0' size='30'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/IsUrlMatcher.java' bugCount='0' size='23'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/MapContainsEntriesMatcher.java' bugCount='0' size='18'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/MatchesRegexMatcher.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/ReflectionMatchers.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/StringMatchers.java' bugCount='0' size='8'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/TransactionalMatchers.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/test/hamcrest/UrlMatchers.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/test/mockito/ReflectionMatchers.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/test/mockito/StringMatchers.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/utilities/AnnotationEqualityHelper.java' bugCount='0' size='111'></FileStats>
-    <FileStats path='com/aconex/utilities/ArgumentValidator.java' bugCount='0' size='41'></FileStats>
-    <FileStats path='com/aconex/utilities/BeanUtils.java' bugCount='1' bugHash='57903c4cd534a91c3276cfdc1fd68481' size='9'></FileStats>
-    <FileStats path='com/aconex/utilities/ConfigConstants.java' bugCount='0' size='6'></FileStats>
-    <FileStats path='com/aconex/utilities/CryptographyException.java' bugCount='0' size='14'></FileStats>
-    <FileStats path='com/aconex/utilities/DataManipulation.java' bugCount='0' size='92'></FileStats>
-    <FileStats path='com/aconex/utilities/EnumUtils.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/utilities/EqualityField.java' bugCount='0' size='1'></FileStats>
-    <FileStats path='com/aconex/utilities/FormUtils.java' bugCount='0' size='16'></FileStats>
-    <FileStats path='com/aconex/utilities/GuidGenerator.java' bugCount='0' size='5'></FileStats>
-    <FileStats path='com/aconex/utilities/HTMLFormat.java' bugCount='0' size='56'></FileStats>
-    <FileStats path='com/aconex/utilities/HTMLFormatRules.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/utilities/JMXUtils.java' bugCount='0' size='25'></FileStats>
-    <FileStats path='com/aconex/utilities/NumberUtils.java' bugCount='1' bugHash='61c1c3f5ce459cc689664af48d0d4937' size='10'></FileStats>
-    <FileStats path='com/aconex/utilities/SHA1.java' bugCount='0' size='199'></FileStats>
-    <FileStats path='com/aconex/utilities/StringEscapeUtils.java' bugCount='1' bugHash='57c340add2bc35c912e992f3563bcc49' size='13'></FileStats>
-    <FileStats path='com/aconex/utilities/StringTrimingUtils.java' bugCount='0' size='20'></FileStats>
-    <FileStats path='com/aconex/utilities/TimingStatistics.java' bugCount='1' bugHash='d1af948812058a7cc55e1db4b430f739' size='49'></FileStats>
-    <FileStats path='com/aconex/utilities/TransientHolder.java' bugCount='0' size='13'></FileStats>
-    <FileStats path='com/aconex/utilities/URLUtils.java' bugCount='1' bugHash='4052709d5c28d2a20b24f26c3de7b610' size='137'></FileStats>
-    <FileStats path='com/aconex/utilities/ValidationUtils.java' bugCount='0' size='11'></FileStats>
-    <FileStats path='com/aconex/utilities/XMLUtils.java' bugCount='1' bugHash='35317315f7ba8f065bf25d8d053ab644' size='26'></FileStats>
-    <FileStats path='com/aconex/utilities/XStreamUtils.java' bugCount='0' size='24'></FileStats>
-    <FileStats path='com/aconex/utilities/browser/BrowserProperties.java' bugCount='3' bugHash='2c246e8b51cb9ef542b03f352e0eb65f' size='120'></FileStats>
-    <FileStats path='com/aconex/utilities/browser/BrowserSniffer.java' bugCount='8' bugHash='34c025ada75d51e089cffd88dcd045a7' size='115'></FileStats>
-    <FileStats path='com/aconex/utilities/db/ConnectionIdSource.java' bugCount='0' size='29'></FileStats>
-    <FileStats path='com/aconex/utilities/db/LoggingDriver.java' bugCount='7' bugHash='553a0de7c357f4c0f8f14ec7c2a7b861' size='560'></FileStats>
-    <FileStats path='com/aconex/utilities/db/MDCLoggerDataSource.java' bugCount='0' size='41'></FileStats>
-    <FileStats path='com/aconex/utilities/db/SQLServerUtils.java' bugCount='0' size='21'></FileStats>
-    <FileStats path='com/aconex/utilities/decorators/AbstractDecorator.java' bugCount='0' size='8'></FileStats>
-    <FileStats path='com/aconex/utilities/decorators/AbstractRunnableDecorator.java' bugCount='0' size='4'></FileStats>
-    <FileStats path='com/aconex/utilities/decorators/Decorator.java' bugCount='0' size='12'></FileStats>
-    <FileStats path='com/aconex/utilities/encoder/DigestUtils.java' bugCount='0' size='21'></FileStats>
-    <FileStats path='com/aconex/utilities/message/Message.java' bugCount='1' bugHash='1ca3517a1b6a4b2befa7a4eed133e621' size='35'></FileStats>
-    <FileStats path='com/aconex/utilities/message/MessageContainer.java' bugCount='0' size='60'></FileStats>
-    <FileStats path='com/aconex/utilities/message/MessageType.java' bugCount='0' size='23'></FileStats>
-    <FileStats path='com/aconex/utilities/tuples/Pair.java' bugCount='0' size='67'></FileStats>
-    <FileStats path='com/aconex/utilities/web/binding/editors/AbstractPropertyEditor.java' bugCount='0' size='22'></FileStats>
-    <FileStats path='com/aconex/velocity/VelocityUtils.java' bugCount='3' bugHash='6d4bb5d9a4f2f02a60a26dc816f71a93' size='36'></FileStats>
-    <PackageStats priority_2='1' total_size='495' package='com.aconex.db' total_bugs='3' priority_3='2' total_types='22'>
-      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='com.aconex.db.BulkOperationHandler' interface='true' size='7'></ClassStats>
-      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='com.aconex.db.BulkOperationHandler$1' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='CompositeBulkOperationHandler.java' bugs='0' class='com.aconex.db.CompositeBulkOperationHandler' interface='false' size='26'></ClassStats>
-      <ClassStats sourceFile='DAO.java' bugs='0' class='com.aconex.db.DAO' interface='true' size='8'></ClassStats>
-      <ClassStats sourceFile='DAO.java' bugs='0' class='com.aconex.db.DAO$ObjectRetrievalState' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='DatabaseConstants.java' bugs='0' class='com.aconex.db.DatabaseConstants' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO' interface='false' size='103'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$1' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$2' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$3' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$4' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$5' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$Alias' interface='false' size='20'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$CriteriaSearch' interface='false' size='97'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$CriteriaSearchCallback' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='com.aconex.db.HibernateDAO$JoinType' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='JdbcDAO.java' bugs='0' class='com.aconex.db.JdbcDAO' interface='false' size='16'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='JdbcSettingsMBean.java' bugs='1' class='com.aconex.db.JdbcSettingsMBean' interface='false' size='20'></ClassStats>
-      <ClassStats sourceFile='KeyedPersistable.java' bugs='0' class='com.aconex.db.KeyedPersistable' interface='true' size='2'></ClassStats>
-      <ClassStats sourceFile='LegacyHibernateFlushingDAO.java' bugs='0' class='com.aconex.db.LegacyHibernateFlushingDAO' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='LegacyService.java' bugs='2' class='com.aconex.db.LegacyService' interface='false' priority_3='2' size='73'></ClassStats>
-      <ClassStats sourceFile='OrderDirection.java' bugs='0' class='com.aconex.db.OrderDirection' interface='false' size='11'></ClassStats>
+    <FileStats path='somepakage/db/BulkOperationHandler.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepakage/db/CompositeBulkOperationHandler.java' bugCount='0' size='26'></FileStats>
+    <FileStats path='somepakage/db/DAO.java' bugCount='0' size='19'></FileStats>
+    <FileStats path='somepakage/db/DatabaseConstants.java' bugCount='0' size='5'></FileStats>
+    <FileStats path='somepakage/db/HibernateDAO.java' bugCount='0' size='295'></FileStats>
+    <FileStats path='somepakage/db/JdbcDAO.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepakage/db/JdbcSettingsMBean.java' bugCount='1' bugHash='c5e12ef8b4c3b5761631ee80aa03ba0a' size='20'></FileStats>
+    <FileStats path='somepakage/db/KeyedPersistable.java' bugCount='0' size='2'></FileStats>
+    <FileStats path='somepakage/db/LegacyHibernateFlushingDAO.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/db/LegacyService.java' bugCount='2' bugHash='12e55d926b38eb819d258c757ff8842d' size='73'></FileStats>
+    <FileStats path='somepakage/db/OrderDirection.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepakage/db/hibernate/InExpression.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepakage/db/hibernate/LikeExpression.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/db/hibernate/BaseInExpression.java' bugCount='1' bugHash='f98a9b1e595d46d6770b05fae4ec7e9a' size='35'></FileStats>
+    <FileStats path='somepakage/db/hibernate/HibernateBulkOperationHandler.java' bugCount='0' size='58'></FileStats>
+    <FileStats path='somepakage/db/hibernate/HibernateCallbackWithoutResult.java' bugCount='0' size='7'></FileStats>
+    <FileStats path='somepakage/db/hibernate/HibernateKeyEqualityHelper.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/db/hibernate/HibernatePausingBulkOperationHandler.java' bugCount='0' size='20'></FileStats>
+    <FileStats path='somepakage/db/hibernate/IdentifierInExpression.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepakage/db/hibernate/NativeSQLOrder.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepakage/db/hibernate/OptionalRestrictions.java' bugCount='0' size='33'></FileStats>
+    <FileStats path='somepakage/db/hibernate/OrderingUtils.java' bugCount='0' size='7'></FileStats>
+    <FileStats path='somepakage/db/hibernate/Restrictions.java' bugCount='0' size='89'></FileStats>
+    <FileStats path='somepakage/db/usertypes/KeyedEnumUserType.java' bugCount='1' bugHash='29ebc0e6cf8b9d964eead37d91cb6702' size='66'></FileStats>
+    <FileStats path='somepakage/db/usertypes/XStreamUserType.java' bugCount='1' bugHash='c02a68e22c20663da99cecc766d4673c' size='37'></FileStats>
+    <FileStats path='somepakage/lockable/Lockable.java' bugCount='0' size='7'></FileStats>
+    <FileStats path='somepakage/lockable/LockableSupport.java' bugCount='1' bugHash='84009006b1915ceafcb90f3f55754296' size='29'></FileStats>
+    <FileStats path='somepakage/lockable/LockedException.java' bugCount='0' size='8'></FileStats>
+    <FileStats path='somepakage/monitoring/MonitoredBeanPredicates.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepakage/monitoring/RequestId.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepakage/monitoring/TimedRunnable.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepakage/pdf/jobTicket/XMLElement.java' bugCount='2' bugHash='b6186363a00367c77f5236cff985d159' size='68'></FileStats>
+    <FileStats path='somepakage/security/util/PhoneticUtils.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/specification/OrSpecification.java' bugCount='0' size='10'></FileStats>
+    <FileStats path='somepakage/specification/Specification.java' bugCount='0' size='2'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/CollectionMatchers.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsAnnotatedWithMatcher.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsCollectionContainingInAnyOrderMatcher.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsDeeplySerializableMatcher.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsImmutableMatcher.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsListContainingInOrderMatcher.java' bugCount='0' size='17'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsListEmptyMatcher.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsMapEmptyMatcher.java' bugCount='0' size='9'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsMemberPackageProtectedMatcher.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsMemberPublicMatcher.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsOfLengthMatcher.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsTransactionalMatcher.java' bugCount='0' size='30'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/IsUrlMatcher.java' bugCount='0' size='23'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/MapContainsEntriesMatcher.java' bugCount='0' size='18'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/MatchesRegexMatcher.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/ReflectionMatchers.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/StringMatchers.java' bugCount='0' size='8'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/TransactionalMatchers.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepakage/test/hamcrest/UrlMatchers.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepakage/test/mockito/ReflectionMatchers.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepakage/test/mockito/StringMatchers.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepakage/utilities/AnnotationEqualityHelper.java' bugCount='0' size='111'></FileStats>
+    <FileStats path='somepakage/utilities/ArgumentValidator.java' bugCount='0' size='41'></FileStats>
+    <FileStats path='somepakage/utilities/BeanUtils.java' bugCount='1' bugHash='57903c4cd534a91c3276cfdc1fd68481' size='9'></FileStats>
+    <FileStats path='somepakage/utilities/ConfigConstants.java' bugCount='0' size='6'></FileStats>
+    <FileStats path='somepakage/utilities/CryptographyException.java' bugCount='0' size='14'></FileStats>
+    <FileStats path='somepakage/utilities/DataManipulation.java' bugCount='0' size='92'></FileStats>
+    <FileStats path='somepakage/utilities/EnumUtils.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/utilities/EqualityField.java' bugCount='0' size='1'></FileStats>
+    <FileStats path='somepakage/utilities/FormUtils.java' bugCount='0' size='16'></FileStats>
+    <FileStats path='somepakage/utilities/GuidGenerator.java' bugCount='0' size='5'></FileStats>
+    <FileStats path='somepakage/utilities/HTMLFormat.java' bugCount='0' size='56'></FileStats>
+    <FileStats path='somepakage/utilities/HTMLFormatRules.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepakage/utilities/JMXUtils.java' bugCount='0' size='25'></FileStats>
+    <FileStats path='somepakage/utilities/NumberUtils.java' bugCount='1' bugHash='61c1c3f5ce459cc689664af48d0d4937' size='10'></FileStats>
+    <FileStats path='somepakage/utilities/SHA1.java' bugCount='0' size='199'></FileStats>
+    <FileStats path='somepakage/utilities/StringEscapeUtils.java' bugCount='1' bugHash='57c340add2bc35c912e992f3563bcc49' size='13'></FileStats>
+    <FileStats path='somepakage/utilities/StringTrimingUtils.java' bugCount='0' size='20'></FileStats>
+    <FileStats path='somepakage/utilities/TimingStatistics.java' bugCount='1' bugHash='d1af948812058a7cc55e1db4b430f739' size='49'></FileStats>
+    <FileStats path='somepakage/utilities/TransientHolder.java' bugCount='0' size='13'></FileStats>
+    <FileStats path='somepakage/utilities/URLUtils.java' bugCount='1' bugHash='4052709d5c28d2a20b24f26c3de7b610' size='137'></FileStats>
+    <FileStats path='somepakage/utilities/ValidationUtils.java' bugCount='0' size='11'></FileStats>
+    <FileStats path='somepakage/utilities/XMLUtils.java' bugCount='1' bugHash='35317315f7ba8f065bf25d8d053ab644' size='26'></FileStats>
+    <FileStats path='somepakage/utilities/XStreamUtils.java' bugCount='0' size='24'></FileStats>
+    <FileStats path='somepakage/utilities/browser/BrowserProperties.java' bugCount='3' bugHash='2c246e8b51cb9ef542b03f352e0eb65f' size='120'></FileStats>
+    <FileStats path='somepakage/utilities/browser/BrowserSniffer.java' bugCount='8' bugHash='34c025ada75d51e089cffd88dcd045a7' size='115'></FileStats>
+    <FileStats path='somepakage/utilities/db/ConnectionIdSource.java' bugCount='0' size='29'></FileStats>
+    <FileStats path='somepakage/utilities/db/LoggingDriver.java' bugCount='7' bugHash='553a0de7c357f4c0f8f14ec7c2a7b861' size='560'></FileStats>
+    <FileStats path='somepakage/utilities/db/MDCLoggerDataSource.java' bugCount='0' size='41'></FileStats>
+    <FileStats path='somepakage/utilities/db/SQLServerUtils.java' bugCount='0' size='21'></FileStats>
+    <FileStats path='somepakage/utilities/decorators/AbstractDecorator.java' bugCount='0' size='8'></FileStats>
+    <FileStats path='somepakage/utilities/decorators/AbstractRunnableDecorator.java' bugCount='0' size='4'></FileStats>
+    <FileStats path='somepakage/utilities/decorators/Decorator.java' bugCount='0' size='12'></FileStats>
+    <FileStats path='somepakage/utilities/encoder/DigestUtils.java' bugCount='0' size='21'></FileStats>
+    <FileStats path='somepakage/utilities/message/Message.java' bugCount='1' bugHash='1ca3517a1b6a4b2befa7a4eed133e621' size='35'></FileStats>
+    <FileStats path='somepakage/utilities/message/MessageContainer.java' bugCount='0' size='60'></FileStats>
+    <FileStats path='somepakage/utilities/message/MessageType.java' bugCount='0' size='23'></FileStats>
+    <FileStats path='somepakage/utilities/tuples/Pair.java' bugCount='0' size='67'></FileStats>
+    <FileStats path='somepakage/utilities/web/binding/editors/AbstractPropertyEditor.java' bugCount='0' size='22'></FileStats>
+    <FileStats path='somepakage/velocity/VelocityUtils.java' bugCount='3' bugHash='6d4bb5d9a4f2f02a60a26dc816f71a93' size='36'></FileStats>
+    <PackageStats priority_2='1' total_size='495' package='somepakage.db' total_bugs='3' priority_3='2' total_types='22'>
+      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='somepakage.db.BulkOperationHandler' interface='true' size='7'></ClassStats>
+      <ClassStats sourceFile='BulkOperationHandler.java' bugs='0' class='somepakage.db.BulkOperationHandler$1' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='CompositeBulkOperationHandler.java' bugs='0' class='somepakage.db.CompositeBulkOperationHandler' interface='false' size='26'></ClassStats>
+      <ClassStats sourceFile='DAO.java' bugs='0' class='somepakage.db.DAO' interface='true' size='8'></ClassStats>
+      <ClassStats sourceFile='DAO.java' bugs='0' class='somepakage.db.DAO$ObjectRetrievalState' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='DatabaseConstants.java' bugs='0' class='somepakage.db.DatabaseConstants' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO' interface='false' size='103'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$1' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$2' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$3' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$4' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$5' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$Alias' interface='false' size='20'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$CriteriaSearch' interface='false' size='97'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$CriteriaSearchCallback' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='HibernateDAO.java' bugs='0' class='somepakage.db.HibernateDAO$JoinType' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='JdbcDAO.java' bugs='0' class='somepakage.db.JdbcDAO' interface='false' size='16'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='JdbcSettingsMBean.java' bugs='1' class='somepakage.db.JdbcSettingsMBean' interface='false' size='20'></ClassStats>
+      <ClassStats sourceFile='KeyedPersistable.java' bugs='0' class='somepakage.db.KeyedPersistable' interface='true' size='2'></ClassStats>
+      <ClassStats sourceFile='LegacyHibernateFlushingDAO.java' bugs='0' class='somepakage.db.LegacyHibernateFlushingDAO' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='LegacyService.java' bugs='2' class='somepakage.db.LegacyService' interface='false' priority_3='2' size='73'></ClassStats>
+      <ClassStats sourceFile='OrderDirection.java' bugs='0' class='somepakage.db.OrderDirection' interface='false' size='11'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='1' total_size='309' package='com.aconex.db.hibernate' total_bugs='1' total_types='17'>
-      <ClassStats sourceFile='AconexInExpression.java' bugs='0' class='com.aconex.db.hibernate.AconexInExpression' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='AconexLikeExpression.java' bugs='0' class='com.aconex.db.hibernate.AconexLikeExpression' interface='false' size='12'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='BaseInExpression.java' bugs='1' class='com.aconex.db.hibernate.BaseInExpression' interface='false' size='35'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler' interface='false' size='31'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$1' interface='false' size='1'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$SessionOperation' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$SessionOperation$1' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernateBulkOperationHandler$SessionOperation$2' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='HibernateCallbackWithoutResult.java' bugs='0' class='com.aconex.db.hibernate.HibernateCallbackWithoutResult' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='HibernateKeyEqualityHelper.java' bugs='0' class='com.aconex.db.hibernate.HibernateKeyEqualityHelper' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernatePausingBulkOperationHandler' interface='false' size='15'></ClassStats>
-      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='com.aconex.db.hibernate.HibernatePausingBulkOperationHandler$TransactionInProgressException' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='IdentifierInExpression.java' bugs='0' class='com.aconex.db.hibernate.IdentifierInExpression' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='NativeSQLOrder.java' bugs='0' class='com.aconex.db.hibernate.NativeSQLOrder' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='OptionalRestrictions.java' bugs='0' class='com.aconex.db.hibernate.OptionalRestrictions' interface='false' size='33'></ClassStats>
-      <ClassStats sourceFile='OrderingUtils.java' bugs='0' class='com.aconex.db.hibernate.OrderingUtils' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='Restrictions.java' bugs='0' class='com.aconex.db.hibernate.Restrictions' interface='false' size='89'></ClassStats>
+    <PackageStats priority_2='1' total_size='309' package='somepakage.db.hibernate' total_bugs='1' total_types='17'>
+      <ClassStats sourceFile='InExpression.java' bugs='0' class='somepakage.db.hibernate.InExpression' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='LikeExpression.java' bugs='0' class='somepakage.db.hibernate.LikeExpression' interface='false' size='12'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='BaseInExpression.java' bugs='1' class='somepakage.db.hibernate.BaseInExpression' interface='false' size='35'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernateBulkOperationHandler' interface='false' size='31'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernateBulkOperationHandler$1' interface='false' size='1'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernateBulkOperationHandler$SessionOperation' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernateBulkOperationHandler$SessionOperation$1' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HibernateBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernateBulkOperationHandler$SessionOperation$2' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='HibernateCallbackWithoutResult.java' bugs='0' class='somepakage.db.hibernate.HibernateCallbackWithoutResult' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='HibernateKeyEqualityHelper.java' bugs='0' class='somepakage.db.hibernate.HibernateKeyEqualityHelper' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernatePausingBulkOperationHandler' interface='false' size='15'></ClassStats>
+      <ClassStats sourceFile='HibernatePausingBulkOperationHandler.java' bugs='0' class='somepakage.db.hibernate.HibernatePausingBulkOperationHandler$TransactionInProgressException' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='IdentifierInExpression.java' bugs='0' class='somepakage.db.hibernate.IdentifierInExpression' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='NativeSQLOrder.java' bugs='0' class='somepakage.db.hibernate.NativeSQLOrder' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='OptionalRestrictions.java' bugs='0' class='somepakage.db.hibernate.OptionalRestrictions' interface='false' size='33'></ClassStats>
+      <ClassStats sourceFile='OrderingUtils.java' bugs='0' class='somepakage.db.hibernate.OrderingUtils' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='Restrictions.java' bugs='0' class='somepakage.db.hibernate.Restrictions' interface='false' size='89'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='2' total_size='103' package='com.aconex.db.usertypes' total_bugs='2' total_types='2'>
-      <ClassStats priority_2='1' sourceFile='KeyedEnumUserType.java' bugs='1' class='com.aconex.db.usertypes.KeyedEnumUserType' interface='false' size='66'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='XStreamUserType.java' bugs='1' class='com.aconex.db.usertypes.XStreamUserType' interface='false' size='37'></ClassStats>
+    <PackageStats priority_2='2' total_size='103' package='somepakage.db.usertypes' total_bugs='2' total_types='2'>
+      <ClassStats priority_2='1' sourceFile='KeyedEnumUserType.java' bugs='1' class='somepakage.db.usertypes.KeyedEnumUserType' interface='false' size='66'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='XStreamUserType.java' bugs='1' class='somepakage.db.usertypes.XStreamUserType' interface='false' size='37'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='44' package='com.aconex.lockable' total_bugs='1' priority_3='1' total_types='3'>
-      <ClassStats sourceFile='Lockable.java' bugs='0' class='com.aconex.lockable.Lockable' interface='true' size='7'></ClassStats>
-      <ClassStats sourceFile='LockableSupport.java' bugs='1' class='com.aconex.lockable.LockableSupport' interface='false' priority_3='1' size='29'></ClassStats>
-      <ClassStats sourceFile='LockedException.java' bugs='0' class='com.aconex.lockable.LockedException' interface='false' size='8'></ClassStats>
+    <PackageStats total_size='44' package='somepakage.lockable' total_bugs='1' priority_3='1' total_types='3'>
+      <ClassStats sourceFile='Lockable.java' bugs='0' class='somepakage.lockable.Lockable' interface='true' size='7'></ClassStats>
+      <ClassStats sourceFile='LockableSupport.java' bugs='1' class='somepakage.lockable.LockableSupport' interface='false' priority_3='1' size='29'></ClassStats>
+      <ClassStats sourceFile='LockedException.java' bugs='0' class='somepakage.lockable.LockedException' interface='false' size='8'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='33' package='com.aconex.monitoring' total_bugs='0' total_types='3'>
-      <ClassStats sourceFile='MonitoredBeanPredicates.java' bugs='0' class='com.aconex.monitoring.MonitoredBeanPredicates' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='RequestId.java' bugs='0' class='com.aconex.monitoring.RequestId' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='TimedRunnable.java' bugs='0' class='com.aconex.monitoring.TimedRunnable' interface='false' size='18'></ClassStats>
+    <PackageStats total_size='33' package='somepakage.monitoring' total_bugs='0' total_types='3'>
+      <ClassStats sourceFile='MonitoredBeanPredicates.java' bugs='0' class='somepakage.monitoring.MonitoredBeanPredicates' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='RequestId.java' bugs='0' class='somepakage.monitoring.RequestId' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='TimedRunnable.java' bugs='0' class='somepakage.monitoring.TimedRunnable' interface='false' size='18'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='2' total_size='68' package='com.aconex.pdf.jobTicket' total_bugs='2' total_types='2'>
-      <ClassStats sourceFile='XMLElement.java' bugs='0' class='com.aconex.pdf.jobTicket.XMLElement' interface='false' size='50'></ClassStats>
-      <ClassStats priority_2='2' sourceFile='XMLElement.java' bugs='2' class='com.aconex.pdf.jobTicket.XMLElement$AllowedStringsPredicate' interface='false' size='18'></ClassStats>
+    <PackageStats priority_2='2' total_size='68' package='somepakage.pdf.jobTicket' total_bugs='2' total_types='2'>
+      <ClassStats sourceFile='XMLElement.java' bugs='0' class='somepakage.pdf.jobTicket.XMLElement' interface='false' size='50'></ClassStats>
+      <ClassStats priority_2='2' sourceFile='XMLElement.java' bugs='2' class='somepakage.pdf.jobTicket.XMLElement$AllowedStringsPredicate' interface='false' size='18'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='12' package='com.aconex.security.util' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='PhoneticUtils.java' bugs='0' class='com.aconex.security.util.PhoneticUtils' interface='false' size='12'></ClassStats>
+    <PackageStats total_size='12' package='somepakage.security.util' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='PhoneticUtils.java' bugs='0' class='somepakage.security.util.PhoneticUtils' interface='false' size='12'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='12' package='com.aconex.specification' total_bugs='0' total_types='2'>
-      <ClassStats sourceFile='OrSpecification.java' bugs='0' class='com.aconex.specification.OrSpecification' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='Specification.java' bugs='0' class='com.aconex.specification.Specification' interface='true' size='2'></ClassStats>
+    <PackageStats total_size='12' package='somepakage.specification' total_bugs='0' total_types='2'>
+      <ClassStats sourceFile='OrSpecification.java' bugs='0' class='somepakage.specification.OrSpecification' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='Specification.java' bugs='0' class='somepakage.specification.Specification' interface='true' size='2'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='264' package='com.aconex.test.hamcrest' total_bugs='0' total_types='19'>
-      <ClassStats sourceFile='CollectionMatchers.java' bugs='0' class='com.aconex.test.hamcrest.CollectionMatchers' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='IsAnnotatedWithMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsAnnotatedWithMatcher' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='IsCollectionContainingInAnyOrderMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsCollectionContainingInAnyOrderMatcher' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='IsDeeplySerializableMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsDeeplySerializableMatcher' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='IsImmutableMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsImmutableMatcher' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='IsListContainingInOrderMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsListContainingInOrderMatcher' interface='false' size='17'></ClassStats>
-      <ClassStats sourceFile='IsListEmptyMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsListEmptyMatcher' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='IsMapEmptyMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsMapEmptyMatcher' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='IsMemberPackageProtectedMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsMemberPackageProtectedMatcher' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='IsMemberPublicMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsMemberPublicMatcher' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='IsOfLengthMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsOfLengthMatcher' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='IsTransactionalMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsTransactionalMatcher' interface='false' size='30'></ClassStats>
-      <ClassStats sourceFile='IsUrlMatcher.java' bugs='0' class='com.aconex.test.hamcrest.IsUrlMatcher' interface='false' size='23'></ClassStats>
-      <ClassStats sourceFile='MapContainsEntriesMatcher.java' bugs='0' class='com.aconex.test.hamcrest.MapContainsEntriesMatcher' interface='false' size='18'></ClassStats>
-      <ClassStats sourceFile='MatchesRegexMatcher.java' bugs='0' class='com.aconex.test.hamcrest.MatchesRegexMatcher' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='com.aconex.test.hamcrest.ReflectionMatchers' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='com.aconex.test.hamcrest.StringMatchers' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='TransactionalMatchers.java' bugs='0' class='com.aconex.test.hamcrest.TransactionalMatchers' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='UrlMatchers.java' bugs='0' class='com.aconex.test.hamcrest.UrlMatchers' interface='false' size='6'></ClassStats>
+    <PackageStats total_size='264' package='somepakage.test.hamcrest' total_bugs='0' total_types='19'>
+      <ClassStats sourceFile='CollectionMatchers.java' bugs='0' class='somepakage.test.hamcrest.CollectionMatchers' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='IsAnnotatedWithMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsAnnotatedWithMatcher' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='IsCollectionContainingInAnyOrderMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsCollectionContainingInAnyOrderMatcher' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='IsDeeplySerializableMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsDeeplySerializableMatcher' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='IsImmutableMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsImmutableMatcher' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='IsListContainingInOrderMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsListContainingInOrderMatcher' interface='false' size='17'></ClassStats>
+      <ClassStats sourceFile='IsListEmptyMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsListEmptyMatcher' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='IsMapEmptyMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsMapEmptyMatcher' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='IsMemberPackageProtectedMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsMemberPackageProtectedMatcher' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='IsMemberPublicMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsMemberPublicMatcher' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='IsOfLengthMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsOfLengthMatcher' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='IsTransactionalMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsTransactionalMatcher' interface='false' size='30'></ClassStats>
+      <ClassStats sourceFile='IsUrlMatcher.java' bugs='0' class='somepakage.test.hamcrest.IsUrlMatcher' interface='false' size='23'></ClassStats>
+      <ClassStats sourceFile='MapContainsEntriesMatcher.java' bugs='0' class='somepakage.test.hamcrest.MapContainsEntriesMatcher' interface='false' size='18'></ClassStats>
+      <ClassStats sourceFile='MatchesRegexMatcher.java' bugs='0' class='somepakage.test.hamcrest.MatchesRegexMatcher' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='somepakage.test.hamcrest.ReflectionMatchers' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='somepakage.test.hamcrest.StringMatchers' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='TransactionalMatchers.java' bugs='0' class='somepakage.test.hamcrest.TransactionalMatchers' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='UrlMatchers.java' bugs='0' class='somepakage.test.hamcrest.UrlMatchers' interface='false' size='6'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='27' package='com.aconex.test.mockito' total_bugs='0' total_types='4'>
-      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='com.aconex.test.mockito.ReflectionMatchers' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='com.aconex.test.mockito.ReflectionMatchers$1' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='com.aconex.test.mockito.StringMatchers' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='com.aconex.test.mockito.StringMatchers$1' interface='false' size='5'></ClassStats>
+    <PackageStats total_size='27' package='somepakage.test.mockito' total_bugs='0' total_types='4'>
+      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='somepakage.test.mockito.ReflectionMatchers' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='ReflectionMatchers.java' bugs='0' class='somepakage.test.mockito.ReflectionMatchers$1' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='somepakage.test.mockito.StringMatchers' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='StringMatchers.java' bugs='0' class='somepakage.test.mockito.StringMatchers$1' interface='false' size='5'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='1' priority_1='3' total_size='903' package='com.aconex.utilities' total_bugs='6' priority_3='2' total_types='28'>
-      <ClassStats sourceFile='AnnotationEqualityHelper.java' bugs='0' class='com.aconex.utilities.AnnotationEqualityHelper' interface='false' size='111'></ClassStats>
-      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='com.aconex.utilities.ArgumentValidator' interface='false' size='34'></ClassStats>
-      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='com.aconex.utilities.ArgumentValidator$1' interface='false' size='7'></ClassStats>
-      <ClassStats priority_1='1' sourceFile='BeanUtils.java' bugs='1' class='com.aconex.utilities.BeanUtils' interface='false' size='9'></ClassStats>
-      <ClassStats sourceFile='ConfigConstants.java' bugs='0' class='com.aconex.utilities.ConfigConstants' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='CryptographyException.java' bugs='0' class='com.aconex.utilities.CryptographyException' interface='false' size='14'></ClassStats>
-      <ClassStats sourceFile='DataManipulation.java' bugs='0' class='com.aconex.utilities.DataManipulation' interface='false' size='92'></ClassStats>
-      <ClassStats sourceFile='EnumUtils.java' bugs='0' class='com.aconex.utilities.EnumUtils' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='EqualityField.java' bugs='0' class='com.aconex.utilities.EqualityField' interface='true' size='1'></ClassStats>
-      <ClassStats sourceFile='FormUtils.java' bugs='0' class='com.aconex.utilities.FormUtils' interface='false' size='16'></ClassStats>
-      <ClassStats sourceFile='GuidGenerator.java' bugs='0' class='com.aconex.utilities.GuidGenerator' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat' interface='false' size='38'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat$1' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat$2' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='com.aconex.utilities.HTMLFormat$3' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='HTMLFormatRules.java' bugs='0' class='com.aconex.utilities.HTMLFormatRules' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='JMXUtils.java' bugs='0' class='com.aconex.utilities.JMXUtils' interface='false' size='25'></ClassStats>
-      <ClassStats priority_1='1' sourceFile='NumberUtils.java' bugs='1' class='com.aconex.utilities.NumberUtils' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='SHA1.java' bugs='0' class='com.aconex.utilities.SHA1' interface='false' size='199'></ClassStats>
-      <ClassStats priority_1='1' sourceFile='StringEscapeUtils.java' bugs='1' class='com.aconex.utilities.StringEscapeUtils' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='StringTrimingUtils.java' bugs='0' class='com.aconex.utilities.StringTrimingUtils' interface='false' size='20'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='TimingStatistics.java' bugs='1' class='com.aconex.utilities.TimingStatistics' interface='false' size='49'></ClassStats>
-      <ClassStats sourceFile='TransientHolder.java' bugs='0' class='com.aconex.utilities.TransientHolder' interface='false' size='13'></ClassStats>
-      <ClassStats sourceFile='URLUtils.java' bugs='1' class='com.aconex.utilities.URLUtils' interface='false' priority_3='1' size='137'></ClassStats>
-      <ClassStats sourceFile='ValidationUtils.java' bugs='0' class='com.aconex.utilities.ValidationUtils' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='XMLUtils.java' bugs='1' class='com.aconex.utilities.XMLUtils' interface='false' priority_3='1' size='26'></ClassStats>
-      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='com.aconex.utilities.XStreamUtils' interface='false' size='19'></ClassStats>
-      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='com.aconex.utilities.XStreamUtils$1' interface='false' size='5'></ClassStats>
+    <PackageStats priority_2='1' priority_1='3' total_size='903' package='somepakage.utilities' total_bugs='6' priority_3='2' total_types='28'>
+      <ClassStats sourceFile='AnnotationEqualityHelper.java' bugs='0' class='somepakage.utilities.AnnotationEqualityHelper' interface='false' size='111'></ClassStats>
+      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='somepakage.utilities.ArgumentValidator' interface='false' size='34'></ClassStats>
+      <ClassStats sourceFile='ArgumentValidator.java' bugs='0' class='somepakage.utilities.ArgumentValidator$1' interface='false' size='7'></ClassStats>
+      <ClassStats priority_1='1' sourceFile='BeanUtils.java' bugs='1' class='somepakage.utilities.BeanUtils' interface='false' size='9'></ClassStats>
+      <ClassStats sourceFile='ConfigConstants.java' bugs='0' class='somepakage.utilities.ConfigConstants' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='CryptographyException.java' bugs='0' class='somepakage.utilities.CryptographyException' interface='false' size='14'></ClassStats>
+      <ClassStats sourceFile='DataManipulation.java' bugs='0' class='somepakage.utilities.DataManipulation' interface='false' size='92'></ClassStats>
+      <ClassStats sourceFile='EnumUtils.java' bugs='0' class='somepakage.utilities.EnumUtils' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='EqualityField.java' bugs='0' class='somepakage.utilities.EqualityField' interface='true' size='1'></ClassStats>
+      <ClassStats sourceFile='FormUtils.java' bugs='0' class='somepakage.utilities.FormUtils' interface='false' size='16'></ClassStats>
+      <ClassStats sourceFile='GuidGenerator.java' bugs='0' class='somepakage.utilities.GuidGenerator' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepakage.utilities.HTMLFormat' interface='false' size='38'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepakage.utilities.HTMLFormat$1' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepakage.utilities.HTMLFormat$2' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HTMLFormat.java' bugs='0' class='somepakage.utilities.HTMLFormat$3' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='HTMLFormatRules.java' bugs='0' class='somepakage.utilities.HTMLFormatRules' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='JMXUtils.java' bugs='0' class='somepakage.utilities.JMXUtils' interface='false' size='25'></ClassStats>
+      <ClassStats priority_1='1' sourceFile='NumberUtils.java' bugs='1' class='somepakage.utilities.NumberUtils' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='SHA1.java' bugs='0' class='somepakage.utilities.SHA1' interface='false' size='199'></ClassStats>
+      <ClassStats priority_1='1' sourceFile='StringEscapeUtils.java' bugs='1' class='somepakage.utilities.StringEscapeUtils' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='StringTrimingUtils.java' bugs='0' class='somepakage.utilities.StringTrimingUtils' interface='false' size='20'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='TimingStatistics.java' bugs='1' class='somepakage.utilities.TimingStatistics' interface='false' size='49'></ClassStats>
+      <ClassStats sourceFile='TransientHolder.java' bugs='0' class='somepakage.utilities.TransientHolder' interface='false' size='13'></ClassStats>
+      <ClassStats sourceFile='URLUtils.java' bugs='1' class='somepakage.utilities.URLUtils' interface='false' priority_3='1' size='137'></ClassStats>
+      <ClassStats sourceFile='ValidationUtils.java' bugs='0' class='somepakage.utilities.ValidationUtils' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='XMLUtils.java' bugs='1' class='somepakage.utilities.XMLUtils' interface='false' priority_3='1' size='26'></ClassStats>
+      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='somepakage.utilities.XStreamUtils' interface='false' size='19'></ClassStats>
+      <ClassStats sourceFile='XStreamUtils.java' bugs='0' class='somepakage.utilities.XStreamUtils$1' interface='false' size='5'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='235' package='com.aconex.utilities.browser' total_bugs='11' priority_3='11' total_types='2'>
-      <ClassStats sourceFile='BrowserProperties.java' bugs='3' class='com.aconex.utilities.browser.BrowserProperties' interface='false' priority_3='3' size='120'></ClassStats>
-      <ClassStats sourceFile='BrowserSniffer.java' bugs='8' class='com.aconex.utilities.browser.BrowserSniffer' interface='false' priority_3='8' size='115'></ClassStats>
+    <PackageStats total_size='235' package='somepakage.utilities.browser' total_bugs='11' priority_3='11' total_types='2'>
+      <ClassStats sourceFile='BrowserProperties.java' bugs='3' class='somepakage.utilities.browser.BrowserProperties' interface='false' priority_3='3' size='120'></ClassStats>
+      <ClassStats sourceFile='BrowserSniffer.java' bugs='8' class='somepakage.utilities.browser.BrowserSniffer' interface='false' priority_3='8' size='115'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='3' total_size='651' package='com.aconex.utilities.db' total_bugs='7' priority_3='4' total_types='17'>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource' interface='true' size='7'></ClassStats>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource$1' interface='false' size='5'></ClassStats>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource$2' interface='false' size='10'></ClassStats>
-      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='com.aconex.utilities.db.ConnectionIdSource$2$1' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver' interface='false' size='103'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$1' interface='false' size='6'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler' interface='false' priority_3='1' size='76'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' interface='false' size='25'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' interface='false' size='39'></ClassStats>
-      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor' interface='false' size='162'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$1' interface='false' size='7'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='3' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' interface='false' priority_3='3' size='103'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$CpuWarningFilter' interface='false' size='11'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$IoWarningFilter' interface='false' size='12'></ClassStats>
-      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='com.aconex.utilities.db.LoggingDriver$LoggingDriverMonitor$WarningFilter' interface='false' size='16'></ClassStats>
-      <ClassStats sourceFile='MDCLoggerDataSource.java' bugs='0' class='com.aconex.utilities.db.MDCLoggerDataSource' interface='false' size='41'></ClassStats>
-      <ClassStats sourceFile='SQLServerUtils.java' bugs='0' class='com.aconex.utilities.db.SQLServerUtils' interface='false' size='21'></ClassStats>
+    <PackageStats priority_2='3' total_size='651' package='somepakage.utilities.db' total_bugs='7' priority_3='4' total_types='17'>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepakage.utilities.db.ConnectionIdSource' interface='true' size='7'></ClassStats>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepakage.utilities.db.ConnectionIdSource$1' interface='false' size='5'></ClassStats>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepakage.utilities.db.ConnectionIdSource$2' interface='false' size='10'></ClassStats>
+      <ClassStats sourceFile='ConnectionIdSource.java' bugs='0' class='somepakage.utilities.db.ConnectionIdSource$2$1' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepakage.utilities.db.LoggingDriver' interface='false' size='103'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepakage.utilities.db.LoggingDriver$1' interface='false' size='6'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='1' class='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler' interface='false' priority_3='1' size='76'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$ResultSetInvocationHandler' interface='false' size='25'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='somepakage.utilities.db.LoggingDriver$ConnectionInvocationHandler$StatementInvocationHandler' interface='false' size='39'></ClassStats>
+      <ClassStats priority_2='1' sourceFile='LoggingDriver.java' bugs='1' class='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor' interface='false' size='162'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$1' interface='false' size='7'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='3' class='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog' interface='false' priority_3='3' size='103'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$CpuWarningFilter' interface='false' size='11'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$QueryLog$IoWarningFilter' interface='false' size='12'></ClassStats>
+      <ClassStats sourceFile='LoggingDriver.java' bugs='0' class='somepakage.utilities.db.LoggingDriver$LoggingDriverMonitor$WarningFilter' interface='false' size='16'></ClassStats>
+      <ClassStats sourceFile='MDCLoggerDataSource.java' bugs='0' class='somepakage.utilities.db.MDCLoggerDataSource' interface='false' size='41'></ClassStats>
+      <ClassStats sourceFile='SQLServerUtils.java' bugs='0' class='somepakage.utilities.db.SQLServerUtils' interface='false' size='21'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='24' package='com.aconex.utilities.decorators' total_bugs='0' total_types='4'>
-      <ClassStats sourceFile='AbstractDecorator.java' bugs='0' class='com.aconex.utilities.decorators.AbstractDecorator' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='AbstractRunnableDecorator.java' bugs='0' class='com.aconex.utilities.decorators.AbstractRunnableDecorator' interface='false' size='4'></ClassStats>
-      <ClassStats sourceFile='Decorator.java' bugs='0' class='com.aconex.utilities.decorators.Decorator' interface='true' size='2'></ClassStats>
-      <ClassStats sourceFile='Decorator.java' bugs='0' class='com.aconex.utilities.decorators.Decorator$Helper' interface='false' size='10'></ClassStats>
+    <PackageStats total_size='24' package='somepakage.utilities.decorators' total_bugs='0' total_types='4'>
+      <ClassStats sourceFile='AbstractDecorator.java' bugs='0' class='somepakage.utilities.decorators.AbstractDecorator' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='AbstractRunnableDecorator.java' bugs='0' class='somepakage.utilities.decorators.AbstractRunnableDecorator' interface='false' size='4'></ClassStats>
+      <ClassStats sourceFile='Decorator.java' bugs='0' class='somepakage.utilities.decorators.Decorator' interface='true' size='2'></ClassStats>
+      <ClassStats sourceFile='Decorator.java' bugs='0' class='somepakage.utilities.decorators.Decorator$Helper' interface='false' size='10'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='21' package='com.aconex.utilities.encoder' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='DigestUtils.java' bugs='0' class='com.aconex.utilities.encoder.DigestUtils' interface='false' size='21'></ClassStats>
+    <PackageStats total_size='21' package='somepakage.utilities.encoder' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='DigestUtils.java' bugs='0' class='somepakage.utilities.encoder.DigestUtils' interface='false' size='21'></ClassStats>
     </PackageStats>
-    <PackageStats priority_2='1' total_size='118' package='com.aconex.utilities.message' total_bugs='1' total_types='5'>
-      <ClassStats priority_2='1' sourceFile='Message.java' bugs='1' class='com.aconex.utilities.message.Message' interface='false' size='35'></ClassStats>
-      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='com.aconex.utilities.message.MessageContainer' interface='false' size='44'></ClassStats>
-      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='com.aconex.utilities.message.MessageContainer$1' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='com.aconex.utilities.message.MessageContainer$2' interface='false' size='8'></ClassStats>
-      <ClassStats sourceFile='MessageType.java' bugs='0' class='com.aconex.utilities.message.MessageType' interface='false' size='23'></ClassStats>
+    <PackageStats priority_2='1' total_size='118' package='somepakage.utilities.message' total_bugs='1' total_types='5'>
+      <ClassStats priority_2='1' sourceFile='Message.java' bugs='1' class='somepakage.utilities.message.Message' interface='false' size='35'></ClassStats>
+      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='somepakage.utilities.message.MessageContainer' interface='false' size='44'></ClassStats>
+      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='somepakage.utilities.message.MessageContainer$1' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='MessageContainer.java' bugs='0' class='somepakage.utilities.message.MessageContainer$2' interface='false' size='8'></ClassStats>
+      <ClassStats sourceFile='MessageType.java' bugs='0' class='somepakage.utilities.message.MessageType' interface='false' size='23'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='67' package='com.aconex.utilities.tuples' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='Pair.java' bugs='0' class='com.aconex.utilities.tuples.Pair' interface='false' size='67'></ClassStats>
+    <PackageStats total_size='67' package='somepakage.utilities.tuples' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='Pair.java' bugs='0' class='somepakage.utilities.tuples.Pair' interface='false' size='67'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='22' package='com.aconex.utilities.web.binding.editors' total_bugs='0' total_types='1'>
-      <ClassStats sourceFile='AbstractPropertyEditor.java' bugs='0' class='com.aconex.utilities.web.binding.editors.AbstractPropertyEditor' interface='false' size='22'></ClassStats>
+    <PackageStats total_size='22' package='somepakage.utilities.web.binding.editors' total_bugs='0' total_types='1'>
+      <ClassStats sourceFile='AbstractPropertyEditor.java' bugs='0' class='somepakage.utilities.web.binding.editors.AbstractPropertyEditor' interface='false' size='22'></ClassStats>
     </PackageStats>
-    <PackageStats total_size='36' package='com.aconex.velocity' total_bugs='3' priority_3='3' total_types='1'>
-      <ClassStats sourceFile='VelocityUtils.java' bugs='3' class='com.aconex.velocity.VelocityUtils' interface='false' priority_3='3' size='36'></ClassStats>
+    <PackageStats total_size='36' package='somepakage.velocity' total_bugs='3' priority_3='3' total_types='1'>
+      <ClassStats sourceFile='VelocityUtils.java' bugs='3' class='somepakage.velocity.VelocityUtils' interface='false' priority_3='3' size='36'></ClassStats>
     </PackageStats>
     <FindBugsProfile>
       <ClassProfile avgMicrosecondsPerInvocation='84' maxMicrosecondsPerInvocation='868' name='edu.umd.cs.findbugs.detect.NumberConstructor' invocations='135' totalMilliseconds='11' standardDeviationMircosecondsPerInvocation='126'></ClassProfile>

--- a/dybdob-detectors/src/test/resources/findsecbugsXml.xml
+++ b/dybdob-detectors/src/test/resources/findsecbugsXml.xml
@@ -1,0 +1,940 @@
+<BugCollection sequence='0' release='' analysisTimestamp='1521798814683' version='3.0.0' timestamp='1521700297000'>
+    <Project projectName='aconex-utils-unittest'>
+        <Plugin id='com.h3xstream.findsecbugs' enabled='true'></Plugin>
+    </Project>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='1eb0b331c1e0e380ceac30bd1fccc830' cweid='89' rank='12'
+                 abbrev='SECSQLISPRJDBC' category='SECURITY' priority='2' type='SQL_INJECTION_SPRING_JDBC'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential JDBC Injection (Spring JDBC)</ShortMessage>
+        <LongMessage>This use of org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J can be
+            vulnerable to SQL injection
+        </LongMessage>
+        <Class classname='somepackage.DBUnitHelper' primary='true'>
+            <SourceLine classname='somepackage.DBUnitHelper' start='25' end='118'
+                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'>
+                <Message>At AconexAconexDBUnitHelper.java:[lines 25-118]</Message>
+            </SourceLine>
+            <Message>In class somepackage.DBUnitHelper</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.DBUnitHelper'
+                signature='(Ljava/lang/String;Ljava/lang/String;)J' name='getLongValue' primary='true'>
+            <SourceLine endBytecode='156' classname='somepackage.DBUnitHelper' start='73' end='77'
+                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                        startBytecode='0'></SourceLine>
+            <Message>In method somepackage.DBUnitHelper.getLongValue(String, String)</Message>
+        </Method>
+        <SourceLine endBytecode='23' classname='somepackage.DBUnitHelper' start='74' end='74'
+                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    startBytecode='23' primary='true'>
+            <Message>At AconexDBUnitHelper.java:[line 74]</Message>
+        </SourceLine>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;'>
+            <Message>Unknown source java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+            </Message>
+        </String>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J</Message>
+        </String>
+        <String role='Method usage' value='not detected'>
+            <Message>Method usage not detected</Message>
+        </String>
+        <SourceLine endBytecode='14' classname='somepackage.DBUnitHelper' start='73' end='73'
+                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    startBytecode='14'>
+            <Message>At AconexDBUnitHelper.java:[line 73]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='10' classname='somepackage.DummyKeyProvider' start='27' end='27'
+                    sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
+                    startBytecode='10'>
+            <Message>At DummyKeyProvider.java:[line 27]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='3' classname='somepackage.DummyKeyProvider' start='60' end='60'
+                    sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
+                    startBytecode='3'>
+            <Message>At DummyKeyProvider.java:[line 60]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='3' classname='somepackage.DummyKeyProvider' start='66' end='66'
+                    sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
+                    startBytecode='3'>
+            <Message>At DummyKeyProvider.java:[line 66]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='37' classname='somepackage.DummyKeyProvider' start='78' end='78'
+                    sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
+                    startBytecode='37'>
+            <Message>At DummyKeyProvider.java:[line 78]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='19' classname='somepackage.KeyProviderUtil' start='33' end='33'
+                    sourcepath='somepackage/KeyProviderUtil.java' sourcefile='KeyProviderUtil.java'
+                    startBytecode='19'>
+            <Message>At KeyProviderUtil.java:[line 33]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='22eb9a89dd99454787de1550b70e437b' cweid='89' rank='12'
+                 abbrev='SECSQLISPRJDBC' category='SECURITY' priority='2' type='SQL_INJECTION_SPRING_JDBC'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential JDBC Injection (Spring JDBC)</ShortMessage>
+        <LongMessage>This use of org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I can be
+            vulnerable to SQL injection
+        </LongMessage>
+        <Class classname='somepackage.DBUnitHelper' primary='true'>
+            <SourceLine classname='somepackage.DBUnitHelper' start='25' end='118'
+                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'>
+                <Message>At AconexDBUnitHelper.java:[lines 25-118]</Message>
+            </SourceLine>
+            <Message>In class somepackage.DBUnitHelper</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.DBUnitHelper'
+                signature='(Ljava/lang/String;Ljava/lang/String;)I' name='getValue' primary='true'>
+            <SourceLine endBytecode='156' classname='somepackage.DBUnitHelper' start='83' end='87'
+                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                        startBytecode='0'></SourceLine>
+            <Message>In method somepackage.DBUnitHelper.getValue(String, String)</Message>
+        </Method>
+        <SourceLine endBytecode='23' classname='somepackage.DBUnitHelper' start='84' end='84'
+                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    startBytecode='23' primary='true'>
+            <Message>At AconexDBUnitHelper.java:[line 84]</Message>
+        </SourceLine>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;'>
+            <Message>Unknown source java/lang/String.format(Ljava/lang/String;[Ljava/lang/Object;)Ljava/lang/String;
+            </Message>
+        </String>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I</Message>
+        </String>
+        <String role='Method usage' value='not detected'>
+            <Message>Method usage not detected</Message>
+        </String>
+        <SourceLine endBytecode='14' classname='somepackage.DBUnitHelper' start='83' end='83'
+                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    startBytecode='14'>
+            <Message>At AconexDBUnitHelper.java:[line 83]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='37' classname='somepackage.DummyKeyProvider' start='40' end='40'
+                    sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
+                    startBytecode='37'>
+            <Message>At DummyKeyProvider.java:[line 40]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='19' classname='somepackage.KeyProviderUtil' start='25' end='25'
+                    sourcepath='somepackage/KeyProviderUtil.java' sourcefile='KeyProviderUtil.java'
+                    startBytecode='19'>
+            <Message>At KeyProviderUtil.java:[line 25]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='e6ca726bad2c77952d9e00c95dfb939' cweid='89' rank='15'
+                 abbrev='SECSQLIJDBC' category='SECURITY' priority='3' type='SQL_INJECTION_JDBC'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential JDBC Injection</ShortMessage>
+        <LongMessage>This use of java/sql/Statement.execute(Ljava/lang/String;)Z can be vulnerable to SQL injection
+        </LongMessage>
+        <Class classname='somepackage.HsqlDBUnitHelper' primary='true'>
+            <SourceLine classname='somepackage.HsqlDBUnitHelper' start='19' end='65'
+                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'>
+                <Message>At HsqlAconexDBUnitHelper.java:[lines 19-65]</Message>
+            </SourceLine>
+            <Message>In class somepackage.HsqlDBUnitHelper</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.HsqlDBUnitHelper' signature='(Ljava/lang/String;)V'
+                name='executeSql' primary='true'>
+            <SourceLine endBytecode='243' classname='somepackage.HsqlDBUnitHelper' start='54' end='65'
+                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                        startBytecode='0'></SourceLine>
+            <Message>In method somepackage.HsqlDBUnitHelper.executeSql(String)</Message>
+        </Method>
+        <SourceLine endBytecode='19' classname='somepackage.HsqlDBUnitHelper' start='58' end='58'
+                    sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                    startBytecode='19' primary='true'>
+            <Message>At HsqlAconexDBUnitHelper.java:[line 58]</Message>
+        </SourceLine>
+        <String role='Sink method' value='java/sql/Statement.execute(Ljava/lang/String;)Z'>
+            <Message>Sink method java/sql/Statement.execute(Ljava/lang/String;)Z</Message>
+        </String>
+        <String role='Sink method' value='java/sql/Statement.execute(Ljava/lang/String;)Z'>
+            <Message>Sink method java/sql/Statement.execute(Ljava/lang/String;)Z</Message>
+        </String>
+        <String role='Method usage' value='detected only with safe arguments'>
+            <Message>Method usage detected only with safe arguments</Message>
+        </String>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='a9579b8071f4269c08914bed6425b5b1' cweid='89' rank='15'
+                 abbrev='SQL' category='SECURITY' priority='3' type='SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Nonconstant string passed to execute method on an SQL statement</ShortMessage>
+        <LongMessage>somepackage.HsqlDBUnitHelper.executeSql(String) passes a nonconstant String to an execute method
+            on an SQL statement
+        </LongMessage>
+        <Class classname='somepackage.HsqlDBUnitHelper' primary='true'>
+            <SourceLine classname='somepackage.HsqlDBUnitHelper' start='19' end='65'
+                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'>
+                <Message>At HsqlAconexDBUnitHelper.java:[lines 19-65]</Message>
+            </SourceLine>
+            <Message>In class somepackage.HsqlDBUnitHelper</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.HsqlDBUnitHelper' signature='(Ljava/lang/String;)V'
+                name='executeSql' primary='true'>
+            <SourceLine endBytecode='27' classname='somepackage.HsqlDBUnitHelper' start='54' end='65'
+                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                        startBytecode='0'></SourceLine>
+            <Message>In method somepackage.HsqlDBUnitHelper.executeSql(String)</Message>
+        </Method>
+        <SourceLine endBytecode='19' classname='somepackage.HsqlDBUnitHelper' start='58' end='58'
+                    sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                    startBytecode='19' primary='true'>
+            <Message>At HsqlAconexDBUnitHelper.java:[line 58]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='c933a095ae3c36494e8ae29a3244f318' cweid='89' rank='12'
+                 abbrev='SECSQLISPRJDBC' category='SECURITY' priority='2' type='SQL_INJECTION_SPRING_JDBC'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential JDBC Injection (Spring JDBC)</ShortMessage>
+        <LongMessage>This use of org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I can be
+            vulnerable to SQL injection
+        </LongMessage>
+        <Class classname='somepackage.BaseHibernateInMemTestCase' primary='true'>
+            <SourceLine classname='somepackage.BaseHibernateInMemTestCase' start='49' end='374'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java'>
+                <Message>At BaseHibernateInMemTestCase.java:[lines 49-374]</Message>
+            </SourceLine>
+            <Message>In class somepackage.BaseHibernateInMemTestCase</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.BaseHibernateInMemTestCase'
+                signature='(Ljava/lang/String;)I' name='countRowsInTable' primary='true'>
+            <SourceLine endBytecode='90' classname='somepackage.BaseHibernateInMemTestCase' start='344' end='344'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java' startBytecode='0'></SourceLine>
+            <Message>In method somepackage.BaseHibernateInMemTestCase.countRowsInTable(String)</Message>
+        </Method>
+        <SourceLine endBytecode='35' classname='somepackage.BaseHibernateInMemTestCase' start='344' end='344'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='35' primary='true'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 344]</Message>
+        </SourceLine>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source' value='java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;</Message>
+        </String>
+        <String role='Unknown source' value='java/lang/StringBuilder.toString()Ljava/lang/String;'>
+            <Message>Unknown source java/lang/StringBuilder.toString()Ljava/lang/String;</Message>
+        </String>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I</Message>
+        </String>
+        <String role='Method usage' value='not detected'>
+            <Message>Method usage not detected</Message>
+        </String>
+        <SourceLine endBytecode='24' classname='somepackage.BaseHibernateInMemTestCase' start='344' end='344'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='24'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 344]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='7e4e900e69d468d0876abbe5ff590218' cweid='89' rank='12'
+                 abbrev='SECSQLISPRJDBC' category='SECURITY' priority='2' type='SQL_INJECTION_SPRING_JDBC'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential JDBC Injection (Spring JDBC)</ShortMessage>
+        <LongMessage>This use of
+            org/springframework/jdbc/core/JdbcTemplate.query(Ljava/lang/String;Lorg/springframework/jdbc/core/RowCallbackHandler;)V
+            can be vulnerable to SQL injection
+        </LongMessage>
+        <Class classname='somepackage.BaseHibernateInMemTestCase' primary='true'>
+            <SourceLine classname='somepackage.BaseHibernateInMemTestCase' start='49' end='374'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java'>
+                <Message>At BaseHibernateInMemTestCase.java:[lines 49-374]</Message>
+            </SourceLine>
+            <Message>In class somepackage.BaseHibernateInMemTestCase</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.BaseHibernateInMemTestCase'
+                signature='(Ljava/lang/String;Ljava/lang/String;)V' name='dumpTable' primary='true'>
+            <SourceLine endBytecode='191' classname='somepackage.BaseHibernateInMemTestCase' start='241' end='252'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java' startBytecode='0'></SourceLine>
+            <Message>In method somepackage.BaseHibernateInMemTestCase.dumpTable(String, String)</Message>
+        </Method>
+        <SourceLine endBytecode='81' classname='somepackage.BaseHibernateInMemTestCase' start='243' end='243'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='81' primary='true'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 243]</Message>
+        </SourceLine>
+        <String role='Sink method'
+                value='org/springframework/jdbc/core/JdbcTemplate.query(Ljava/lang/String;Lorg/springframework/jdbc/core/RowCallbackHandler;)V'>
+            <Message>Sink method
+                org/springframework/jdbc/core/JdbcTemplate.query(Ljava/lang/String;Lorg/springframework/jdbc/core/RowCallbackHandler;)V
+            </Message>
+        </String>
+        <String role='Unknown source' value='java/lang/StringBuilder.toString()Ljava/lang/String;'>
+            <Message>Unknown source java/lang/StringBuilder.toString()Ljava/lang/String;</Message>
+        </String>
+        <String role='Unknown source' value='java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(C)Ljava/lang/StringBuilder;</Message>
+        </String>
+        <String role='Unknown source' value='java/lang/StringBuilder.toString()Ljava/lang/String;'>
+            <Message>Unknown source java/lang/StringBuilder.toString()Ljava/lang/String;</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Sink method'
+                value='org/springframework/jdbc/core/JdbcTemplate.query(Ljava/lang/String;Lorg/springframework/jdbc/core/RowCallbackHandler;)V'>
+            <Message>Sink method
+                org/springframework/jdbc/core/JdbcTemplate.query(Ljava/lang/String;Lorg/springframework/jdbc/core/RowCallbackHandler;)V
+            </Message>
+        </String>
+        <String role='Method usage' value='not detected'>
+            <Message>Method usage not detected</Message>
+        </String>
+        <SourceLine endBytecode='25' classname='somepackage.BaseHibernateInMemTestCase' start='241' end='241'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='25'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 241]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='69' classname='somepackage.BaseHibernateInMemTestCase' start='243' end='243'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='69'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 243]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='75615779358ac2c895d9de7450a1a3c8' cweid='564' rank='12'
+                 abbrev='SECSQLIHIB' category='SECURITY' priority='2' type='SQL_INJECTION_HIBERNATE'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential SQL/HQL Injection (Hibernate)</ShortMessage>
+        <LongMessage>This use of org/hibernate/Session.createSQLQuery(Ljava/lang/String;)Lorg/hibernate/SQLQuery; can be
+            vulnerable to SQL/HQL injection
+        </LongMessage>
+        <Class classname='somepackage.BaseHibernateInMemTestCase$1' primary='true'>
+            <SourceLine classname='somepackage.BaseHibernateInMemTestCase$1' start='182' end='185'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java'>
+                <Message>At BaseHibernateInMemTestCase.java:[lines 182-185]</Message>
+            </SourceLine>
+            <Message>In class somepackage.BaseHibernateInMemTestCase$1</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.BaseHibernateInMemTestCase$1'
+                signature='(Lorg/hibernate/Session;)Ljava/lang/Object;' name='doInHibernate' primary='true'>
+            <SourceLine endBytecode='70' classname='somepackage.BaseHibernateInMemTestCase$1' start='185' end='185'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java' startBytecode='0'></SourceLine>
+            <Message>In method somepackage.BaseHibernateInMemTestCase$1.doInHibernate(Session)</Message>
+        </Method>
+        <SourceLine endBytecode='5' classname='somepackage.BaseHibernateInMemTestCase$1' start='185' end='185'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='5' primary='true'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 185]</Message>
+        </SourceLine>
+        <String role='Sink method'
+                value='org/hibernate/Session.createSQLQuery(Ljava/lang/String;)Lorg/hibernate/SQLQuery;'>
+            <Message>Sink method org/hibernate/Session.createSQLQuery(Ljava/lang/String;)Lorg/hibernate/SQLQuery;
+            </Message>
+        </String>
+        <String role='Unknown source' value='Oups!!'>
+            <Message>Unknown source Oups!!</Message>
+        </String>
+        <String role='Sink method'
+                value='org/hibernate/Session.createSQLQuery(Ljava/lang/String;)Lorg/hibernate/SQLQuery;'>
+            <Message>Sink method org/hibernate/Session.createSQLQuery(Ljava/lang/String;)Lorg/hibernate/SQLQuery;
+            </Message>
+        </String>
+        <SourceLine endBytecode='2' classname='somepackage.BaseHibernateInMemTestCase$1' start='185' end='185'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='2'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 185]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='6067c33235bac7f140e80b33bbb01b4a' cweid='117' rank='15'
+                 abbrev='SECCRLFLOG' category='SECURITY' priority='3' type='CRLF_INJECTION_LOGS'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential CRLF Injection for logs</ShortMessage>
+        <LongMessage>This use of org/apache/log4j/Logger.debug(Ljava/lang/Object;)V might be used to include CRLF
+            characters into log messages
+        </LongMessage>
+        <Class classname='somepackage.BaseHibernateInMemTestCase$2' primary='true'>
+            <SourceLine classname='somepackage.BaseHibernateInMemTestCase$2' start='243' end='250'
+                        sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java'>
+                <Message>At BaseHibernateInMemTestCase.java:[lines 243-250]</Message>
+            </SourceLine>
+            <Message>In class somepackage.BaseHibernateInMemTestCase$2</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.BaseHibernateInMemTestCase$2'
+                signature='(Ljava/sql/ResultSet;)V' name='processRow' primary='true'>
+            <SourceLine endBytecode='215' classname='somepackage.BaseHibernateInMemTestCase$2' start='245'
+                        end='250' sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                        sourcefile='BaseHibernateInMemTestCase.java' startBytecode='0'></SourceLine>
+            <Message>In method somepackage.BaseHibernateInMemTestCase$2.processRow(ResultSet)</Message>
+        </Method>
+        <SourceLine endBytecode='102' classname='somepackage.BaseHibernateInMemTestCase$2' start='249' end='249'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='102' primary='true'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 249]</Message>
+        </SourceLine>
+        <String role='Sink method' value='org/apache/log4j/Logger.debug(Ljava/lang/Object;)V'>
+            <Message>Sink method org/apache/log4j/Logger.debug(Ljava/lang/Object;)V</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source' value='java/lang/StringBuilder.toString()Ljava/lang/String;'>
+            <Message>Unknown source java/lang/StringBuilder.toString()Ljava/lang/String;</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source' value='java/sql/ResultSet.getObject(I)Ljava/lang/Object;'>
+            <Message>Unknown source java/sql/ResultSet.getObject(I)Ljava/lang/Object;</Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/Object;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source'
+                value='java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;'>
+            <Message>Unknown source java/lang/StringBuilder.append(Ljava/lang/String;)Ljava/lang/StringBuilder;
+            </Message>
+        </String>
+        <String role='Unknown source' value='Oups!!'>
+            <Message>Unknown source Oups!!</Message>
+        </String>
+        <String role='Unknown source' value='java/sql/ResultSetMetaData.getColumnName(I)Ljava/lang/String;'>
+            <Message>Unknown source java/sql/ResultSetMetaData.getColumnName(I)Ljava/lang/String;</Message>
+        </String>
+        <String role='Sink method' value='org/apache/log4j/Logger.debug(Ljava/lang/Object;)V'>
+            <Message>Sink method org/apache/log4j/Logger.debug(Ljava/lang/Object;)V</Message>
+        </String>
+        <SourceLine endBytecode='53' classname='somepackage.BaseHibernateInMemTestCase$2' start='247' end='247'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='53'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 247]</Message>
+        </SourceLine>
+        <SourceLine endBytecode='99' classname='somepackage.BaseHibernateInMemTestCase$2' start='249' end='249'
+                    sourcepath='somepackage/BaseHibernateInMemTestCase.java'
+                    sourcefile='BaseHibernateInMemTestCase.java' startBytecode='99'>
+            <Message>At BaseHibernateInMemTestCase.java:[line 249]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugInstance instanceOccurrenceNum='0' instanceHash='df7b78397c117319e17ffeb5915e32d' cweid='89' rank='12'
+                 abbrev='SECSQLISPRJDBC' category='SECURITY' priority='2' type='SQL_INJECTION_SPRING_JDBC'
+                 instanceOccurrenceMax='0'>
+        <ShortMessage>Potential JDBC Injection (Spring JDBC)</ShortMessage>
+        <LongMessage>This use of org/springframework/jdbc/core/JdbcTemplate.execute(Ljava/lang/String;)V can be
+            vulnerable to SQL injection
+        </LongMessage>
+        <Class classname='somepackage.InMemoryDbTestCase' primary='true'>
+            <SourceLine classname='somepackage.InMemoryDbTestCase' start='18' end='64'
+                        sourcepath='somepackage/InMemoryDbTestCase.java' sourcefile='InMemoryDbTestCase.java'>
+                <Message>At InMemoryDbTestCase.java:[lines 18-64]</Message>
+            </SourceLine>
+            <Message>In class somepackage.InMemoryDbTestCase</Message>
+        </Class>
+        <Method isStatic='false' classname='somepackage.InMemoryDbTestCase' signature='([Ljava/lang/String;)V'
+                name='initializeTables' primary='true'>
+            <SourceLine endBytecode='309' classname='somepackage.InMemoryDbTestCase' start='40' end='53'
+                        sourcepath='somepackage/InMemoryDbTestCase.java' sourcefile='InMemoryDbTestCase.java'
+                        startBytecode='0'></SourceLine>
+            <Message>In method somepackage.InMemoryDbTestCase.initializeTables(String[])</Message>
+        </Method>
+        <SourceLine endBytecode='99' classname='somepackage.InMemoryDbTestCase' start='50' end='50'
+                    sourcepath='somepackage/InMemoryDbTestCase.java' sourcefile='InMemoryDbTestCase.java'
+                    startBytecode='99' primary='true'>
+            <Message>At InMemoryDbTestCase.java:[line 50]</Message>
+        </SourceLine>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.execute(Ljava/lang/String;)V'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.execute(Ljava/lang/String;)V</Message>
+        </String>
+        <String role='Unknown source'
+                value='org/apache/commons/io/IOUtils.toString(Ljava/io/InputStream;)Ljava/lang/String;'>
+            <Message>Unknown source org/apache/commons/io/IOUtils.toString(Ljava/io/InputStream;)Ljava/lang/String;
+            </Message>
+        </String>
+        <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.execute(Ljava/lang/String;)V'>
+            <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.execute(Ljava/lang/String;)V</Message>
+        </String>
+        <SourceLine endBytecode='73' classname='somepackage.InMemoryDbTestCase' start='46' end='46'
+                    sourcepath='somepackage/InMemoryDbTestCase.java' sourcefile='InMemoryDbTestCase.java'
+                    startBytecode='73'>
+            <Message>At InMemoryDbTestCase.java:[line 46]</Message>
+        </SourceLine>
+    </BugInstance>
+    <BugCategory category='SECURITY'>
+        <Description>Security</Description>
+    </BugCategory>
+    <BugPattern cweid='89' abbrev='SECSQLIJDBC' category='SECURITY' type='SQL_INJECTION_JDBC'>
+        <ShortDescription>Potential JDBC Injection</ShortDescription>
+        <Details>
+
+            &lt;p&gt;
+            The input values included in SQL queries need to be passed in safely.
+            Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
+            &lt;/p&gt;
+
+            &lt;p&gt;
+            &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;Connection conn = [...];
+            Statement stmt = con.createStatement();
+            ResultSet rs = stmt.executeQuery("update COFFEES set SALES = "+nbSales+" where COF_NAME =
+            '"+coffeeName+"'");&lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;p&gt;
+            &lt;b&gt;Solution:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;Connection conn = [...];
+            conn.prepareStatement("update COFFEES set SALES = ? where COF_NAME = ?");
+            updateSales.setInt(1, nbSales);
+            updateSales.setString(2, coffeeName);&lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;br/&gt;
+
+            &lt;b&gt;References (JDBC)&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="http://docs.oracle.com/javase/tutorial/jdbc/basics/prepared.html"&gt;Oracle Documentation: The
+            Java Tutorials &amp;gt; Prepared Statements&lt;/a&gt;&lt;br/&gt;
+            &lt;b&gt;References (SQL injection)&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection"&gt;WASC-19: SQL Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://capec.mitre.org/data/definitions/66.html"&gt;CAPEC-66: SQL Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://cwe.mitre.org/data/definitions/89.html"&gt;CWE-89: Improper Neutralization of Special
+            Elements used in an SQL Command ('SQL Injection')&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection"&gt;OWASP: Top 10 2013-A1-Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet"&gt;OWASP: SQL Injection
+            Prevention Cheat Sheet&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet"&gt;OWASP: Query
+            Parameterization Cheat Sheet&lt;/a&gt;&lt;br/&gt;
+            &lt;/p&gt;
+
+        </Details>
+    </BugPattern>
+    <BugPattern cweid='117' abbrev='SECCRLFLOG' category='SECURITY' type='CRLF_INJECTION_LOGS'>
+        <ShortDescription>Potential CRLF Injection for logs</ShortDescription>
+        <Details>
+
+            &lt;p&gt;
+            When data from an untrusted source is put into a logger and not neutralized correctly,
+            an attacker could forge log entries or include malicious content.
+            Inserted false entries could be used to skew statistics, distract the administrator
+            or even to implicate another party in the commission of a malicious act.
+            If the log file is processed automatically, the attacker can render the file unusable
+            by corrupting the format of the file or injecting unexpected characters.
+            An attacker may also inject code or other commands into the log file and take advantage
+            of a vulnerability in the log processing utility (e.g. command injection or XSS).
+            &lt;/p&gt;
+            &lt;br/&gt;
+            &lt;p&gt;
+            &lt;b&gt;Code at risk:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;String val = request.getParameter("user");
+            String metadata = request.getParameter("metadata");
+            [...]
+            if(authenticated) {
+            log.info("User " + val + " (" + metadata + ") was authenticated successfully");
+            }
+            else {
+            log.info("User " + val + " (" + metadata + ") was not authenticated");
+            }
+            &lt;/pre&gt;
+
+            A malicious user could send the metadata parameter with the value: &lt;code&gt;"Firefox) was authenticated
+            successfully\r\n[INFO] User bbb (Internet Explorer"&lt;/code&gt;.
+            &lt;/p&gt;
+
+            &lt;b&gt;Solution:&lt;/b&gt;&lt;br/&gt;
+            &lt;p&gt;
+            You can manually sanitize each parameter.
+            &lt;pre&gt;
+            log.info("User " + val.replaceAll("[\r\n]","") + " (" + userAgent.replaceAll("[\r\n]","") + ") was not
+            authenticated");
+            &lt;/pre&gt;
+            &lt;/p&gt;
+
+            &lt;p&gt;
+            You can also configure your logger service to replace new line for all message events. Here is sample
+            configuration for LogBack &lt;a href="https://logback.qos.ch/manual/layouts.html#replace"&gt;using the
+            replace function&lt;/a&gt;.
+            &lt;pre&gt;
+            &amp;lt;pattern&amp;gt;%-5level - %replace(%msg){'[\r\n]', ''}%n&amp;lt;/pattern&amp;gt;
+            &lt;/pre&gt;
+            &lt;/p&gt;
+
+            &lt;br/&gt;
+            &lt;p&gt;
+            &lt;b&gt;References&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="http://cwe.mitre.org/data/definitions/117.html"&gt;CWE-117: Improper Output Neutralization for
+            Logs&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://cwe.mitre.org/data/definitions/93.html"&gt;CWE-93: Improper Neutralization of CRLF
+            Sequences ('CRLF Injection')&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://logback.qos.ch/manual/layouts.html#replace"&gt;CWE-93: Improper Neutralization of CRLF
+            Sequences ('CRLF Injection')&lt;/a&gt;&lt;br/&gt;
+            &lt;/p&gt;
+
+
+        </Details>
+    </BugPattern>
+    <BugPattern cweid='89' abbrev='SQL' category='SECURITY' type='SQL_NONCONSTANT_STRING_PASSED_TO_EXECUTE'>
+        <ShortDescription>Nonconstant string passed to execute method on an SQL statement</ShortDescription>
+        <Details>
+
+            &lt;p&gt;The method invokes the execute method on an SQL statement with a String that seems
+            to be dynamically generated. Consider using
+            a prepared statement instead. It is more efficient and less vulnerable to
+            SQL injection attacks.
+            &lt;/p&gt;
+
+        </Details>
+    </BugPattern>
+    <BugPattern cweid='89' abbrev='SECSQLISPRJDBC' category='SECURITY' type='SQL_INJECTION_SPRING_JDBC'>
+        <ShortDescription>Potential JDBC Injection (Spring JDBC)</ShortDescription>
+        <Details>
+
+            &lt;p&gt;
+            The input values included in SQL queries need to be passed in safely.
+            Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
+            &lt;/p&gt;
+
+            &lt;p&gt;
+            &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;JdbcTemplate jdbc = new JdbcTemplate();
+            int count = jdbc.queryForObject("select count(*) from Users where name = '"+paramName+"'", Integer.class);
+            &lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;p&gt;
+            &lt;b&gt;Solution:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;JdbcTemplate jdbc = new JdbcTemplate();
+            int count = jdbc.queryForObject("select count(*) from Users where name = ?", Integer.class, paramName);&lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;br/&gt;
+
+            &lt;b&gt;References (Spring JDBC)&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="http://docs.spring.io/spring-framework/docs/current/spring-framework-reference/html/jdbc.html"&gt;Spring
+            Official Documentation: Data access with JDBC&lt;/a&gt;&lt;br/&gt;
+            &lt;b&gt;References (SQL injection)&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection"&gt;WASC-19: SQL Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://capec.mitre.org/data/definitions/66.html"&gt;CAPEC-66: SQL Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://cwe.mitre.org/data/definitions/89.html"&gt;CWE-89: Improper Neutralization of Special
+            Elements used in an SQL Command ('SQL Injection')&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection"&gt;OWASP: Top 10 2013-A1-Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet"&gt;OWASP: SQL Injection
+            Prevention Cheat Sheet&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet"&gt;OWASP: Query
+            Parameterization Cheat Sheet&lt;/a&gt;&lt;br/&gt;
+            &lt;/p&gt;
+
+        </Details>
+    </BugPattern>
+    <BugPattern cweid='564' abbrev='SECSQLIHIB' category='SECURITY' type='SQL_INJECTION_HIBERNATE'>
+        <ShortDescription>Potential SQL/HQL Injection (Hibernate)</ShortDescription>
+        <Details>
+
+            &lt;p&gt;
+            The input values included in SQL queries need to be passed in safely.
+            Bind variables in prepared statements can be used to easily mitigate the risk of SQL injection.
+            Alternatively to prepare statements, Hibernate Criteria can be used.
+            &lt;/p&gt;
+            &lt;p&gt;
+            &lt;b&gt;Vulnerable Code:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;
+            Session session = sessionFactory.openSession();
+            Query q = session.createQuery("select t from UserEntity t where id = " + input);
+            q.execute();&lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;p&gt;
+            &lt;b&gt;Solution:&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;
+            Session session = sessionFactory.openSession();
+            Query q = session.createQuery("select t from UserEntity t where id = :userId");
+            q.setString("userId",input);
+            q.execute();&lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;p&gt;
+            &lt;b&gt;Solution for dynamic queries (with Hibernate Criteria):&lt;/b&gt;&lt;br/&gt;
+            &lt;pre&gt;
+            Session session = sessionFactory.openSession();
+            Query q = session.createCriteria(UserEntity.class)
+            .add( Restrictions.like("id", input) )
+            .list();
+            q.execute();&lt;/pre&gt;
+            &lt;/p&gt;
+            &lt;br/&gt;
+            &lt;p&gt;
+            &lt;b&gt;References (Hibernate)&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="https://docs.jboss.org/hibernate/orm/3.3/reference/en/html/querycriteria.html"&gt;Hibernate
+            Documentation: Query Criteria&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://docs.jboss.org/hibernate/orm/3.2/api/org/hibernate/Query.html"&gt;Hibernate Javadoc:
+            Query Object&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://blog.h3xstream.com/2014/02/hql-for-pentesters.html"&gt;HQL for pentesters&lt;/a&gt;:
+            Guideline to test if the suspected code is exploitable.&lt;br/&gt;
+            &lt;b&gt;References (SQL injection)&lt;/b&gt;&lt;br/&gt;
+            &lt;a href="http://projects.webappsec.org/w/page/13246963/SQL%20Injection"&gt;WASC-19: SQL Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://capec.mitre.org/data/definitions/66.html"&gt;CAPEC-66: SQL Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="http://cwe.mitre.org/data/definitions/89.html"&gt;CWE-89: Improper Neutralization of Special
+            Elements used in an SQL Command ('SQL Injection')&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/Top_10_2013-A1-Injection"&gt;OWASP: Top 10 2013-A1-Injection&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/SQL_Injection_Prevention_Cheat_Sheet"&gt;OWASP: SQL Injection
+            Prevention Cheat Sheet&lt;/a&gt;&lt;br/&gt;
+            &lt;a href="https://www.owasp.org/index.php/Query_Parameterization_Cheat_Sheet"&gt;OWASP: Query
+            Parameterization Cheat Sheet&lt;/a&gt;&lt;br/&gt;
+            &lt;/p&gt;
+
+        </Details>
+    </BugPattern>
+    <BugCode abbrev='SECSQLISPRJDBC'>
+        <Description>SQL Injection (Spring JDBC)</Description>
+    </BugCode>
+    <BugCode abbrev='SECCRLFLOG'>
+        <Description>CRLF Injection for logs</Description>
+    </BugCode>
+    <BugCode abbrev='SECSQLIHIB'>
+        <Description>HQL Injection</Description>
+    </BugCode>
+    <BugCode abbrev='SECSQLIJDBC'>
+        <Description>SQL Injection (JDBC)</Description>
+    </BugCode>
+    <BugCode abbrev='SQL'>
+        <Description>Potential SQL Problem</Description>
+    </BugCode>
+    <Errors missingClasses='0' errors='0'></Errors>
+    <FindBugsSummary num_packages='5' total_classes='21' priority_2='6' priority_3='3' total_size='548'
+                     clock_seconds='2.83' referenced_classes='130' vm_version='25.121-b13' total_bugs='9'
+                     java_version='1.8.0_121' gc_seconds='0.07' alloc_mbytes='1365.50' cpu_seconds='12.54'
+                     peak_mbytes='200.72' timestamp='Thu, 22 Mar 2018 12:01:37 +0530'>
+        <FileStats path='somepackage/JsonParser.java' size='11' bugCount='0'></FileStats>
+        <FileStats path='somepackage/builder/DataBuilder.java' size='10' bugCount='0'></FileStats>
+        <FileStats path='somepackage/AconexAconexDBUnitHelper.java' size='65' bugHash='b9a1e8cc143a2ccd602cd2db4b4acb4b'
+                   bugCount='2'></FileStats>
+        <FileStats path='somepackage/DummyKeyProvider.java' size='52' bugCount='0'></FileStats>
+        <FileStats path='somepackage/HsqlAconexDBUnitHelper.java' size='39' bugHash='c6a396ac4d4e0fcd2d843593fd6bfeaa'
+                   bugCount='2'></FileStats>
+        <FileStats path='somepackage/KeyProviderUtil.java' size='21' bugCount='0'></FileStats>
+        <FileStats path='somepackage/hibernate/testing/DummyIdentifierGenerator.java' size='10'
+                   bugCount='0'></FileStats>
+        <FileStats path='somepackage/hibernate/testing/DummyInstanceKeyIdentifierGenerator.java' size='10'
+                   bugCount='0'></FileStats>
+        <FileStats path='somepackage/hibernate/testing/DummyIntAsLongIdentifierGenerator.java' size='10'
+                   bugCount='0'></FileStats>
+        <FileStats path='somepackage/hibernate/testing/DummyLongAsLongIdentifierGenerator.java' size='10'
+                   bugCount='0'></FileStats>
+        <FileStats path='somepackage/hibernate/testing/package-info.java' size='1' bugCount='0'></FileStats>
+        <FileStats path='somepackage/AconexMatchers.java' size='16' bugCount='0'></FileStats>
+        <FileStats path='somepackage/BaseHibernateInMemTestCase.java' size='228'
+                   bugHash='4fef9fed3bca44e679fd779825300c68' bugCount='4'></FileStats>
+        <FileStats path='somepackage/InMemoryDbTestCase.java' size='38' bugHash='fe3a86c51a08938a106dcd3ce3664c1a'
+                   bugCount='1'></FileStats>
+        <FileStats path='somepackage/TestGroups.java' size='27' bugCount='0'></FileStats>
+        <PackageStats package='somepackage' total_bugs='0' total_size='11' total_types='2'>
+            <ClassStats bugs='0' size='8' interface='false' sourceFile='JsonParser.java'
+                        class='somepackage.JsonParser'></ClassStats>
+            <ClassStats bugs='0' size='3' interface='false' sourceFile='JsonParser.java'
+                        class='somepackage.JsonParser$1'></ClassStats>
+        </PackageStats>
+        <PackageStats package='somepackage.builder' total_bugs='0' total_size='10' total_types='1'>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='DataBuilder.java'
+                        class='somepackage.builder.DataBuilder'></ClassStats>
+        </PackageStats>
+        <PackageStats package='somepackage' total_bugs='4' priority_2='2' priority_3='2' total_size='177'
+                      total_types='5'>
+            <ClassStats bugs='2' size='65' priority_2='2' interface='false' sourceFile='AconexAconexDBUnitHelper.java'
+                        class='somepackage.DBUnitHelper'></ClassStats>
+            <ClassStats bugs='0' size='52' interface='false' sourceFile='DummyKeyProvider.java'
+                        class='somepackage.DummyKeyProvider'></ClassStats>
+            <ClassStats bugs='2' size='31' priority_3='2' interface='false' sourceFile='HsqlAconexDBUnitHelper.java'
+                        class='somepackage.HsqlDBUnitHelper'></ClassStats>
+            <ClassStats bugs='0' size='8' interface='false' sourceFile='HsqlAconexDBUnitHelper.java'
+                        class='somepackage.HsqlDBUnitHelper$1'></ClassStats>
+            <ClassStats bugs='0' size='21' interface='false' sourceFile='KeyProviderUtil.java'
+                        class='somepackage.KeyProviderUtil'></ClassStats>
+        </PackageStats>
+        <PackageStats package='somepackage.hibernate.testing' total_bugs='0' total_size='41' total_types='5'>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='DummyIdentifierGenerator.java'
+                        class='somepackage.hibernate.testing.DummyIdentifierGenerator'></ClassStats>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='DummyInstanceKeyIdentifierGenerator.java'
+                        class='somepackage.hibernate.testing.DummyInstanceKeyIdentifierGenerator'></ClassStats>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='DummyIntAsLongIdentifierGenerator.java'
+                        class='somepackage.hibernate.testing.DummyIntAsLongIdentifierGenerator'></ClassStats>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='DummyLongAsLongIdentifierGenerator.java'
+                        class='somepackage.hibernate.testing.DummyLongAsLongIdentifierGenerator'></ClassStats>
+            <ClassStats bugs='0' size='1' interface='true' sourceFile='package-info.java'
+                        class='somepackage.hibernate.testing.package-info'></ClassStats>
+        </PackageStats>
+        <PackageStats package='somepackage' total_bugs='5' priority_2='4' priority_3='1' total_size='309'
+                      total_types='8'>
+            <ClassStats bugs='0' size='6' interface='false' sourceFile='AconexMatchers.java'
+                        class='somepackage.AconexMatchers'></ClassStats>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='AconexMatchers.java'
+                        class='somepackage.AconexMatchers$1'></ClassStats>
+            <ClassStats bugs='2' size='199' priority_2='2' interface='false'
+                        sourceFile='BaseHibernateInMemTestCase.java'
+                        class='somepackage.BaseHibernateInMemTestCase'></ClassStats>
+            <ClassStats bugs='1' size='7' priority_2='1' interface='false' sourceFile='BaseHibernateInMemTestCase.java'
+                        class='somepackage.BaseHibernateInMemTestCase$1'></ClassStats>
+            <ClassStats bugs='1' size='11' priority_3='1' interface='false' sourceFile='BaseHibernateInMemTestCase.java'
+                        class='somepackage.BaseHibernateInMemTestCase$2'></ClassStats>
+            <ClassStats bugs='0' size='11' interface='false' sourceFile='BaseHibernateInMemTestCase.java'
+                        class='somepackage.BaseHibernateInMemTestCase$BatchingBehaviour'></ClassStats>
+            <ClassStats bugs='1' size='38' priority_2='1' interface='false' sourceFile='InMemoryDbTestCase.java'
+                        class='somepackage.InMemoryDbTestCase'></ClassStats>
+            <ClassStats bugs='0' size='27' interface='false' sourceFile='TestGroups.java'
+                        class='somepackage.TestGroups'></ClassStats>
+        </PackageStats>
+        <FindBugsProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='361' totalMilliseconds='368'
+                          name='edu.umd.cs.findbugs.classfile.engine.ClassDataAnalysisEngine'
+                          standardDeviationMircosecondsPerInvocation='502' maxMicrosecondsPerInvocation='14872'
+                          invocations='1017'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='321' totalMilliseconds='325'
+                          name='edu.umd.cs.findbugs.classfile.engine.ClassInfoAnalysisEngine'
+                          standardDeviationMircosecondsPerInvocation='906' maxMicrosecondsPerInvocation='17972'
+                          invocations='1010'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='1038' totalMilliseconds='134'
+                          name='edu.umd.cs.findbugs.detect.FieldItemSummary'
+                          standardDeviationMircosecondsPerInvocation='2605' maxMicrosecondsPerInvocation='20357'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='82' totalMilliseconds='79'
+                          name='edu.umd.cs.findbugs.util.TopologicalSort'
+                          standardDeviationMircosecondsPerInvocation='727' maxMicrosecondsPerInvocation='22500'
+                          invocations='975'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='207' totalMilliseconds='70'
+                          name='edu.umd.cs.findbugs.OpcodeStack$JumpInfoFactory'
+                          standardDeviationMircosecondsPerInvocation='407' maxMicrosecondsPerInvocation='4244'
+                          invocations='338'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='260' totalMilliseconds='57'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.JavaClassAnalysisEngine'
+                          standardDeviationMircosecondsPerInvocation='1194' maxMicrosecondsPerInvocation='16798'
+                          invocations='223'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='437' totalMilliseconds='54'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.IsNullValueDataflowFactory'
+                          standardDeviationMircosecondsPerInvocation='758' maxMicrosecondsPerInvocation='5940'
+                          invocations='125'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='412' totalMilliseconds='51'
+                          name='com.h3xstream.findsecbugs.taintanalysis.TaintDataflowEngine'
+                          standardDeviationMircosecondsPerInvocation='771' maxMicrosecondsPerInvocation='6359'
+                          invocations='125'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='369' totalMilliseconds='48'
+                          name='edu.umd.cs.findbugs.detect.BuildObligationPolicyDatabase'
+                          standardDeviationMircosecondsPerInvocation='1356' maxMicrosecondsPerInvocation='13857'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='366' totalMilliseconds='47'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.MethodGenFactory'
+                          standardDeviationMircosecondsPerInvocation='3052' maxMicrosecondsPerInvocation='34880'
+                          invocations='129'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='348' totalMilliseconds='44'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.TypeDataflowFactory'
+                          standardDeviationMircosecondsPerInvocation='797' maxMicrosecondsPerInvocation='8231'
+                          invocations='129'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='345' totalMilliseconds='44'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.CFGFactory'
+                          standardDeviationMircosecondsPerInvocation='873' maxMicrosecondsPerInvocation='9421'
+                          invocations='129'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='339' totalMilliseconds='43'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.ValueNumberDataflowFactory'
+                          standardDeviationMircosecondsPerInvocation='825' maxMicrosecondsPerInvocation='7953'
+                          invocations='129'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='330' totalMilliseconds='40'
+                          name='edu.umd.cs.findbugs.ba.npe.NullDerefAndRedundantComparisonFinder'
+                          standardDeviationMircosecondsPerInvocation='491' maxMicrosecondsPerInvocation='3532'
+                          invocations='124'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='326' totalMilliseconds='40'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.UnconditionalValueDerefDataflowFactory'
+                          standardDeviationMircosecondsPerInvocation='755' maxMicrosecondsPerInvocation='7902'
+                          invocations='125'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='297' totalMilliseconds='38'
+                          name='edu.umd.cs.findbugs.detect.NoteDirectlyRelevantTypeQualifiers'
+                          standardDeviationMircosecondsPerInvocation='1074' maxMicrosecondsPerInvocation='11263'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='267' totalMilliseconds='34'
+                          name='edu.umd.cs.findbugs.detect.OverridingEqualsNotSymmetrical'
+                          standardDeviationMircosecondsPerInvocation='1314' maxMicrosecondsPerInvocation='14578'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='240' totalMilliseconds='31'
+                          name='edu.umd.cs.findbugs.detect.FunctionsThatMightBeMistakenForProcedures'
+                          standardDeviationMircosecondsPerInvocation='675' maxMicrosecondsPerInvocation='4192'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='1210' totalMilliseconds='25'
+                          name='com.h3xstream.findsecbugs.injection.crlf.CrlfLogInjectionDetector'
+                          standardDeviationMircosecondsPerInvocation='4471' maxMicrosecondsPerInvocation='21123'
+                          invocations='21'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='215' totalMilliseconds='23'
+                          name='edu.umd.cs.findbugs.detect.FindRefComparison$SpecialTypeAnalysis'
+                          standardDeviationMircosecondsPerInvocation='295' maxMicrosecondsPerInvocation='2351'
+                          invocations='109'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='151' totalMilliseconds='19'
+                          name='edu.umd.cs.findbugs.detect.CalledMethods'
+                          standardDeviationMircosecondsPerInvocation='341' maxMicrosecondsPerInvocation='2768'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='168' totalMilliseconds='19'
+                          name='edu.umd.cs.findbugs.classfile.impl.ZipCodeBaseFactory'
+                          standardDeviationMircosecondsPerInvocation='386' maxMicrosecondsPerInvocation='3444'
+                          invocations='116'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='120' totalMilliseconds='15'
+                          name='edu.umd.cs.findbugs.detect.ExplicitSerialization'
+                          standardDeviationMircosecondsPerInvocation='741' maxMicrosecondsPerInvocation='7655'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='114' totalMilliseconds='14'
+                          name='edu.umd.cs.findbugs.detect.EqualsOperandShouldHaveClassCompatibleWithThis'
+                          standardDeviationMircosecondsPerInvocation='278' maxMicrosecondsPerInvocation='1874'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='107' totalMilliseconds='14'
+                          name='edu.umd.cs.findbugs.detect.ReflectiveClasses'
+                          standardDeviationMircosecondsPerInvocation='267' maxMicrosecondsPerInvocation='2313'
+                          invocations='130'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='594' totalMilliseconds='12'
+                          name='edu.umd.cs.findbugs.detect.FindOpenStream'
+                          standardDeviationMircosecondsPerInvocation='1139' maxMicrosecondsPerInvocation='3915'
+                          invocations='21'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='592' totalMilliseconds='12'
+                          name='edu.umd.cs.findbugs.detect.RuntimeExceptionCapture'
+                          standardDeviationMircosecondsPerInvocation='1790' maxMicrosecondsPerInvocation='8420'
+                          invocations='21'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='97' totalMilliseconds='12'
+                          name='edu.umd.cs.findbugs.classfile.engine.bcel.ConstantDataflowFactory'
+                          standardDeviationMircosecondsPerInvocation='204' maxMicrosecondsPerInvocation='1609'
+                          invocations='125'></ClassProfile>
+            <ClassProfile avgMicrosecondsPerInvocation='437' totalMilliseconds='11'
+                          name='edu.umd.cs.findbugs.ba.obl.ObligationAnalysis'
+                          standardDeviationMircosecondsPerInvocation='618' maxMicrosecondsPerInvocation='2510'
+                          invocations='27'></ClassProfile>
+        </FindBugsProfile>
+    </FindBugsSummary>
+    <ClassFeatures></ClassFeatures>
+    <History></History>
+</BugCollection>

--- a/dybdob-detectors/src/test/resources/findsecbugsXml.xml
+++ b/dybdob-detectors/src/test/resources/findsecbugsXml.xml
@@ -1,5 +1,5 @@
 <BugCollection sequence='0' release='' analysisTimestamp='1521798814683' version='3.0.0' timestamp='1521700297000'>
-    <Project projectName='aconex-utils-unittest'>
+    <Project projectName='utils-unittest'>
         <Plugin id='com.h3xstream.findsecbugs' enabled='true'></Plugin>
     </Project>
     <BugInstance instanceOccurrenceNum='0' instanceHash='1eb0b331c1e0e380ceac30bd1fccc830' cweid='89' rank='12'
@@ -11,22 +11,22 @@
         </LongMessage>
         <Class classname='somepackage.DBUnitHelper' primary='true'>
             <SourceLine classname='somepackage.DBUnitHelper' start='25' end='118'
-                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'>
-                <Message>At AconexAconexDBUnitHelper.java:[lines 25-118]</Message>
+                        sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'>
+                <Message>At DBUnitHelper.java:[lines 25-118]</Message>
             </SourceLine>
             <Message>In class somepackage.DBUnitHelper</Message>
         </Class>
         <Method isStatic='false' classname='somepackage.DBUnitHelper'
                 signature='(Ljava/lang/String;Ljava/lang/String;)J' name='getLongValue' primary='true'>
             <SourceLine endBytecode='156' classname='somepackage.DBUnitHelper' start='73' end='77'
-                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                        sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'
                         startBytecode='0'></SourceLine>
             <Message>In method somepackage.DBUnitHelper.getLongValue(String, String)</Message>
         </Method>
         <SourceLine endBytecode='23' classname='somepackage.DBUnitHelper' start='74' end='74'
-                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'
                     startBytecode='23' primary='true'>
-            <Message>At AconexDBUnitHelper.java:[line 74]</Message>
+            <Message>At DBUnitHelper.java:[line 74]</Message>
         </SourceLine>
         <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J'>
             <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForLong(Ljava/lang/String;)J</Message>
@@ -43,9 +43,9 @@
             <Message>Method usage not detected</Message>
         </String>
         <SourceLine endBytecode='14' classname='somepackage.DBUnitHelper' start='73' end='73'
-                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'
                     startBytecode='14'>
-            <Message>At AconexDBUnitHelper.java:[line 73]</Message>
+            <Message>At DBUnitHelper.java:[line 73]</Message>
         </SourceLine>
         <SourceLine endBytecode='10' classname='somepackage.DummyKeyProvider' start='27' end='27'
                     sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
@@ -82,22 +82,22 @@
         </LongMessage>
         <Class classname='somepackage.DBUnitHelper' primary='true'>
             <SourceLine classname='somepackage.DBUnitHelper' start='25' end='118'
-                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'>
-                <Message>At AconexDBUnitHelper.java:[lines 25-118]</Message>
+                        sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'>
+                <Message>At DBUnitHelper.java:[lines 25-118]</Message>
             </SourceLine>
             <Message>In class somepackage.DBUnitHelper</Message>
         </Class>
         <Method isStatic='false' classname='somepackage.DBUnitHelper'
                 signature='(Ljava/lang/String;Ljava/lang/String;)I' name='getValue' primary='true'>
             <SourceLine endBytecode='156' classname='somepackage.DBUnitHelper' start='83' end='87'
-                        sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                        sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'
                         startBytecode='0'></SourceLine>
             <Message>In method somepackage.DBUnitHelper.getValue(String, String)</Message>
         </Method>
         <SourceLine endBytecode='23' classname='somepackage.DBUnitHelper' start='84' end='84'
-                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'
                     startBytecode='23' primary='true'>
-            <Message>At AconexDBUnitHelper.java:[line 84]</Message>
+            <Message>At DBUnitHelper.java:[line 84]</Message>
         </SourceLine>
         <String role='Sink method' value='org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I'>
             <Message>Sink method org/springframework/jdbc/core/JdbcTemplate.queryForInt(Ljava/lang/String;)I</Message>
@@ -114,9 +114,9 @@
             <Message>Method usage not detected</Message>
         </String>
         <SourceLine endBytecode='14' classname='somepackage.DBUnitHelper' start='83' end='83'
-                    sourcepath='somepackage/AconexDBUnitHelper.java' sourcefile='AconexDBUnitHelper.java'
+                    sourcepath='somepackage/DBUnitHelper.java' sourcefile='DBUnitHelper.java'
                     startBytecode='14'>
-            <Message>At AconexDBUnitHelper.java:[line 83]</Message>
+            <Message>At DBUnitHelper.java:[line 83]</Message>
         </SourceLine>
         <SourceLine endBytecode='37' classname='somepackage.DummyKeyProvider' start='40' end='40'
                     sourcepath='somepackage/DummyKeyProvider.java' sourcefile='DummyKeyProvider.java'
@@ -137,22 +137,22 @@
         </LongMessage>
         <Class classname='somepackage.HsqlDBUnitHelper' primary='true'>
             <SourceLine classname='somepackage.HsqlDBUnitHelper' start='19' end='65'
-                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'>
-                <Message>At HsqlAconexDBUnitHelper.java:[lines 19-65]</Message>
+                        sourcepath='somepackage/HsqlDBUnitHelper.java' sourcefile='HsqlDBUnitHelper.java'>
+                <Message>At HsqlDBUnitHelper.java:[lines 19-65]</Message>
             </SourceLine>
             <Message>In class somepackage.HsqlDBUnitHelper</Message>
         </Class>
         <Method isStatic='false' classname='somepackage.HsqlDBUnitHelper' signature='(Ljava/lang/String;)V'
                 name='executeSql' primary='true'>
             <SourceLine endBytecode='243' classname='somepackage.HsqlDBUnitHelper' start='54' end='65'
-                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                        sourcepath='somepackage/HsqlDBUnitHelper.java' sourcefile='HsqlDBUnitHelper.java'
                         startBytecode='0'></SourceLine>
             <Message>In method somepackage.HsqlDBUnitHelper.executeSql(String)</Message>
         </Method>
         <SourceLine endBytecode='19' classname='somepackage.HsqlDBUnitHelper' start='58' end='58'
-                    sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                    sourcepath='somepackage/HsqlDBUnitHelper.java' sourcefile='HsqlDBUnitHelper.java'
                     startBytecode='19' primary='true'>
-            <Message>At HsqlAconexDBUnitHelper.java:[line 58]</Message>
+            <Message>At HsqlDBUnitHelper.java:[line 58]</Message>
         </SourceLine>
         <String role='Sink method' value='java/sql/Statement.execute(Ljava/lang/String;)Z'>
             <Message>Sink method java/sql/Statement.execute(Ljava/lang/String;)Z</Message>
@@ -173,22 +173,22 @@
         </LongMessage>
         <Class classname='somepackage.HsqlDBUnitHelper' primary='true'>
             <SourceLine classname='somepackage.HsqlDBUnitHelper' start='19' end='65'
-                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'>
-                <Message>At HsqlAconexDBUnitHelper.java:[lines 19-65]</Message>
+                        sourcepath='somepackage/HsqlDBUnitHelper.java' sourcefile='HsqlDBUnitHelper.java'>
+                <Message>At HsqlDBUnitHelper.java:[lines 19-65]</Message>
             </SourceLine>
             <Message>In class somepackage.HsqlDBUnitHelper</Message>
         </Class>
         <Method isStatic='false' classname='somepackage.HsqlDBUnitHelper' signature='(Ljava/lang/String;)V'
                 name='executeSql' primary='true'>
             <SourceLine endBytecode='27' classname='somepackage.HsqlDBUnitHelper' start='54' end='65'
-                        sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                        sourcepath='somepackage/HsqlDBUnitHelper.java' sourcefile='HsqlDBUnitHelper.java'
                         startBytecode='0'></SourceLine>
             <Message>In method somepackage.HsqlDBUnitHelper.executeSql(String)</Message>
         </Method>
         <SourceLine endBytecode='19' classname='somepackage.HsqlDBUnitHelper' start='58' end='58'
-                    sourcepath='somepackage/HsqlAconexDBUnitHelper.java' sourcefile='HsqlAconexDBUnitHelper.java'
+                    sourcepath='somepackage/HsqlDBUnitHelper.java' sourcefile='HsqlDBUnitHelper.java'
                     startBytecode='19' primary='true'>
-            <Message>At HsqlAconexDBUnitHelper.java:[line 58]</Message>
+            <Message>At HsqlDBUnitHelper.java:[line 58]</Message>
         </SourceLine>
     </BugInstance>
     <BugInstance instanceOccurrenceNum='0' instanceHash='c933a095ae3c36494e8ae29a3244f318' cweid='89' rank='12'
@@ -740,10 +740,10 @@
                      peak_mbytes='200.72' timestamp='Thu, 22 Mar 2018 12:01:37 +0530'>
         <FileStats path='somepackage/JsonParser.java' size='11' bugCount='0'></FileStats>
         <FileStats path='somepackage/builder/DataBuilder.java' size='10' bugCount='0'></FileStats>
-        <FileStats path='somepackage/AconexAconexDBUnitHelper.java' size='65' bugHash='b9a1e8cc143a2ccd602cd2db4b4acb4b'
+        <FileStats path='somepackage/DBUnitHelper.java' size='65' bugHash='b9a1e8cc143a2ccd602cd2db4b4acb4b'
                    bugCount='2'></FileStats>
         <FileStats path='somepackage/DummyKeyProvider.java' size='52' bugCount='0'></FileStats>
-        <FileStats path='somepackage/HsqlAconexDBUnitHelper.java' size='39' bugHash='c6a396ac4d4e0fcd2d843593fd6bfeaa'
+        <FileStats path='somepackage/HsqlDBUnitHelper.java' size='39' bugHash='c6a396ac4d4e0fcd2d843593fd6bfeaa'
                    bugCount='2'></FileStats>
         <FileStats path='somepackage/KeyProviderUtil.java' size='21' bugCount='0'></FileStats>
         <FileStats path='somepackage/hibernate/testing/DummyIdentifierGenerator.java' size='10'
@@ -755,7 +755,7 @@
         <FileStats path='somepackage/hibernate/testing/DummyLongAsLongIdentifierGenerator.java' size='10'
                    bugCount='0'></FileStats>
         <FileStats path='somepackage/hibernate/testing/package-info.java' size='1' bugCount='0'></FileStats>
-        <FileStats path='somepackage/AconexMatchers.java' size='16' bugCount='0'></FileStats>
+        <FileStats path='somepackage/Matchers.java' size='16' bugCount='0'></FileStats>
         <FileStats path='somepackage/BaseHibernateInMemTestCase.java' size='228'
                    bugHash='4fef9fed3bca44e679fd779825300c68' bugCount='4'></FileStats>
         <FileStats path='somepackage/InMemoryDbTestCase.java' size='38' bugHash='fe3a86c51a08938a106dcd3ce3664c1a'
@@ -773,13 +773,13 @@
         </PackageStats>
         <PackageStats package='somepackage' total_bugs='4' priority_2='2' priority_3='2' total_size='177'
                       total_types='5'>
-            <ClassStats bugs='2' size='65' priority_2='2' interface='false' sourceFile='AconexAconexDBUnitHelper.java'
+            <ClassStats bugs='2' size='65' priority_2='2' interface='false' sourceFile='DBUnitHelper.java'
                         class='somepackage.DBUnitHelper'></ClassStats>
             <ClassStats bugs='0' size='52' interface='false' sourceFile='DummyKeyProvider.java'
                         class='somepackage.DummyKeyProvider'></ClassStats>
-            <ClassStats bugs='2' size='31' priority_3='2' interface='false' sourceFile='HsqlAconexDBUnitHelper.java'
+            <ClassStats bugs='2' size='31' priority_3='2' interface='false' sourceFile='HsqlDBUnitHelper.java'
                         class='somepackage.HsqlDBUnitHelper'></ClassStats>
-            <ClassStats bugs='0' size='8' interface='false' sourceFile='HsqlAconexDBUnitHelper.java'
+            <ClassStats bugs='0' size='8' interface='false' sourceFile='HsqlDBUnitHelper.java'
                         class='somepackage.HsqlDBUnitHelper$1'></ClassStats>
             <ClassStats bugs='0' size='21' interface='false' sourceFile='KeyProviderUtil.java'
                         class='somepackage.KeyProviderUtil'></ClassStats>
@@ -798,10 +798,10 @@
         </PackageStats>
         <PackageStats package='somepackage' total_bugs='5' priority_2='4' priority_3='1' total_size='309'
                       total_types='8'>
-            <ClassStats bugs='0' size='6' interface='false' sourceFile='AconexMatchers.java'
-                        class='somepackage.AconexMatchers'></ClassStats>
-            <ClassStats bugs='0' size='10' interface='false' sourceFile='AconexMatchers.java'
-                        class='somepackage.AconexMatchers$1'></ClassStats>
+            <ClassStats bugs='0' size='6' interface='false' sourceFile='Matchers.java'
+                        class='somepackage.Matchers'></ClassStats>
+            <ClassStats bugs='0' size='10' interface='false' sourceFile='Matchers.java'
+                        class='somepackage.Matchers$1'></ClassStats>
             <ClassStats bugs='2' size='199' priority_2='2' interface='false'
                         sourceFile='BaseHibernateInMemTestCase.java'
                         class='somepackage.BaseHibernateInMemTestCase'></ClassStats>

--- a/dybdob-mojo/src/main/java/com/custardsource/dybdob/mojo/DybdobMojo.java
+++ b/dybdob-mojo/src/main/java/com/custardsource/dybdob/mojo/DybdobMojo.java
@@ -22,7 +22,7 @@ import org.apache.maven.plugin.MojoFailureException;
 public abstract class DybdobMojo extends AbstractMojo {
     private static final List<WarningDetector> KNOWN_DETECTORS = ImmutableList.<WarningDetector>of(
             new JavacWarningDetector(), new CheckstyleDetector(), new CpdDetector(), new PmdDetector(),
-            new FindBugsDetector());
+            new FindBugsDetector("findbugs"), new FindBugsDetector("findsecbugs"));
 
     /**
      * @parameter default-value="${project}"


### PR DESCRIPTION

dybdob checks for the warning count in each module and records it in the database. This is to fail the build it warnings count has gone up. For storing which type of issues we use source column(ex: pmd, checkstyle, findbugs etc), each of the source is having a dybdob detector. Now we need to track the security bugs separately.

As findsecbugs plugin is implemented as an extension to findbugs,  Hence there are no behavioural t changes to [FindBugsDetector.java](https://github.com/Aconex/dybdob/compare/master...santhubairamcs:master#diff-13909398799475d40e5aa0ff8d7ef957) only change is the source name.